### PR TITLE
PAYARA-4006 Tests in hk2-xml does not depend on system locale

### DIFF
--- a/hk2-configuration/persistence/hk2-xml/main/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/main/pom.xml
@@ -124,8 +124,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <!-- Turns on debug logging -->
-                    <argLine>-Dorg.jvnet.hk2.logger.debugToStdout=false -Dorg.jvnet.hk2.properties.xmlservice.jaxb.getsandsets=false ${surefireArgLineExtra}</argLine>
+                    <!-- Turns on debug logging, sets the english language as a default -->
+                    <argLine>
+                      -Dorg.jvnet.hk2.logger.debugToStdout=false
+                      -Dorg.jvnet.hk2.properties.xmlservice.jaxb.getsandsets=false ${surefireArgLineExtra}
+                      -Duser.language=en
+                    </argLine>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
* fixed dependency on system language
* caused tests failing if the default user language was set to other than english