### PR TITLE
PAYARA-4120 Implemented DefaultServiceLocatorErrorService

### DIFF
--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/DefaultServiceLocatorErrorService.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/DefaultServiceLocatorErrorService.java
@@ -1,0 +1,65 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *     The contents of this file are subject to the terms of either the GNU
+ *     General Public License Version 2 only ("GPL") or the Common Development
+ *     and Distribution License("CDDL") (collectively, the "License").  You
+ *     may not use this file except in compliance with the License.  You can
+ *     obtain a copy of the License at
+ *     https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *     See the License for the specific
+ *     language governing permissions and limitations under the License.
+ *
+ *     When distributing the software, include this License Header Notice in each
+ *     file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *     GPL Classpath Exception:
+ *     The Payara Foundation designates this particular file as subject to the "Classpath"
+ *     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *     file that accompanied this code.
+ *
+ *     Modifications:
+ *     If applicable, add the following below the License Header, with the fields
+ *     enclosed by brackets [] replaced by your own identifying information:
+ *     "Portions Copyright [year] [name of copyright owner]"
+ *
+ *     Contributor(s):
+ *     If you wish your version of this file to be governed by only the CDDL or
+ *     only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *     elects to include this software in this distribution under the [CDDL or GPL
+ *     Version 2] license."  If you don't indicate a single choice of license, a
+ *     recipient has the option to distribute your version of this file under
+ *     either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *     its licensees as provided above.  However, if you add GPL Version 2 code
+ *     and therefore, elected the GPL Version 2 license, then the option applies
+ *     only if the new code is made subject to such option by the copyright
+ *     holder.
+ */
+package org.jvnet.hk2.internal;
+
+import org.glassfish.hk2.api.ErrorInformation;
+import org.glassfish.hk2.api.ErrorService;
+import org.glassfish.hk2.api.MultiException;
+
+
+/**
+ * The default error service throwing out all exceptions which can occur in initialization time
+ * until another error services would be configured.
+ *
+ * @author David Matejcek
+ */
+class DefaultServiceLocatorErrorService implements ErrorService {
+
+    @Override
+    public void onFailure(ErrorInformation errorInformation) throws MultiException {
+        if (errorInformation == null) {
+            throw new NullPointerException("errorInformation must not be null!");
+        }
+        if (errorInformation.getAssociatedException() == null) {
+            throw new NullPointerException("errorInformation.getAssociatedException must not be null!");
+        }
+        throw errorInformation.getAssociatedException();
+    }
+}

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/ServiceLocatorImpl.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/ServiceLocatorImpl.java
@@ -173,7 +173,7 @@ public class ServiceLocatorImpl implements ServiceLocator {
     private final LinkedHashSet<ValidationService> allValidators =
             new LinkedHashSet<ValidationService>();
     private final LinkedList<ErrorService> errorHandlers =
-            new LinkedList<ErrorService>();
+            new LinkedList<ErrorService>(Collections.singleton(new DefaultServiceLocatorErrorService()));
     private final LinkedList<ServiceHandle<?>> configListeners =
             new LinkedList<ServiceHandle<?>>();
     


### PR DESCRIPTION
- causes throwing out any exception that can occur in initialization time
- prevent NPE if the initialization was unsuccessful but all exceptions were
  silently swallowed.
- initialization is sucessful and the service is configured OR you catch an exception, but you   
  should not get unconfigured failing locator.