### PR TITLE
PAYARA-4120 Enabled default ErrorService until configured in other way

### DIFF
--- a/hk2-api/src/main/java/org/glassfish/hk2/utilities/IgnoringErrorService.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/utilities/IgnoringErrorService.java
@@ -13,42 +13,30 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-
 package org.glassfish.hk2.utilities;
-
-import java.util.Objects;
 
 import javax.inject.Singleton;
 
 import org.glassfish.hk2.api.ErrorInformation;
 import org.glassfish.hk2.api.ErrorService;
-import org.glassfish.hk2.api.ErrorType;
 import org.glassfish.hk2.api.MultiException;
 
+
 /**
- * This is an implementation of {@link ErrorService} that simply rethrows
+ * This is an implementation of {@link ErrorService} that simply swallows
  * the exception caught.
  * <p>
- * Do not use this service in secure applications where callers to lookup
+ * Use this service in secure applications where callers to lookup
  * should not be given the information that they do NOT have access
  * to a service.
  *
- * @author jwells
  * @author David Matejcek
  */
 @Singleton
-public class RethrowErrorService implements ErrorService {
+public class IgnoringErrorService implements ErrorService {
 
     @Override
     public void onFailure(ErrorInformation errorInformation) throws MultiException {
-        // this may hide the argument, but it would be a really serious bug.
-        Objects.requireNonNull(errorInformation, "errorInformation must not be null!");
-        if (ErrorType.FAILURE_TO_REIFY.equals(errorInformation.getErrorType())) {
-            final MultiException me = errorInformation.getAssociatedException();
-            if (me == null) {
-                return;
-            }
-            throw me;
-        }
+        // completely ignores all errors
     }
 }

--- a/hk2-core/src/main/java/com/sun/enterprise/module/single/StaticModulesRegistry.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/single/StaticModulesRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,6 +26,7 @@ import org.glassfish.hk2.api.DynamicConfigurationService;
 import org.glassfish.hk2.api.MultiException;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.utilities.BuilderHelper;
+import org.glassfish.hk2.utilities.IgnoringErrorService;
 
 /**
  * Implementation of the modules registry that use a single class loader to load
@@ -36,8 +37,8 @@ import org.glassfish.hk2.utilities.BuilderHelper;
  * @author Jerome Dochez
  */
 public class StaticModulesRegistry extends SingleModulesRegistry {
-              
-    final private StartupContext startupContext; 
+
+    final private StartupContext startupContext;
 
     public StaticModulesRegistry(ClassLoader singleCL) {
         super(singleCL);
@@ -72,8 +73,9 @@ public class StaticModulesRegistry extends SingleModulesRegistry {
         DynamicConfigurationService dcs = serviceLocator.getService(DynamicConfigurationService.class);
         DynamicConfiguration config = dcs.createDynamicConfiguration();
         config.bind(BuilderHelper.createConstantDescriptor(sc));
+        config.bind(BuilderHelper.createDescriptorFromClass(IgnoringErrorService.class));
         config.commit();
-        
+
         return serviceLocator;
     }
 

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/ServiceLocatorImpl.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/ServiceLocatorImpl.java
@@ -89,6 +89,7 @@ import org.glassfish.hk2.api.Validator;
 import org.glassfish.hk2.api.messaging.Topic;
 import org.glassfish.hk2.utilities.BuilderHelper;
 import org.glassfish.hk2.utilities.InjecteeImpl;
+import org.glassfish.hk2.utilities.RethrowErrorService;
 import org.glassfish.hk2.utilities.cache.CacheKeyFilter;
 import org.glassfish.hk2.utilities.cache.CacheUtilities;
 import org.glassfish.hk2.utilities.cache.ComputationErrorException;
@@ -151,7 +152,7 @@ public class ServiceLocatorImpl implements ServiceLocator {
     private final LinkedHashSet<ValidationService> allValidators =
             new LinkedHashSet<ValidationService>();
     private final LinkedList<ErrorService> errorHandlers =
-            new LinkedList<ErrorService>();
+            new LinkedList<ErrorService>(Collections.singletonList(new RethrowErrorService()));
     private final LinkedList<ServiceHandle<?>> configListeners =
             new LinkedList<ServiceHandle<?>>();
     

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/negative/classanalysis/ConfigurablyBadClassAnalyzer.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/negative/classanalysis/ConfigurablyBadClassAnalyzer.java
@@ -35,32 +35,32 @@ import org.glassfish.hk2.api.MultiException;
 @Singleton @Named(ConfigurablyBadClassAnalyzer.BAD_ANALYZER_NAME)
 public class ConfigurablyBadClassAnalyzer implements ClassAnalyzer {
     public static final String BAD_ANALYZER_NAME = "BadAnalyzer";
-    
+
     private boolean throwFromConstructor = false;
     private boolean throwFromMethods = false;
     private boolean throwFromFields = false;
     private boolean throwFromPostConstruct = false;
     private boolean throwFromPreDestroy = false;
-    
+
     private boolean nullFromConstructor = false;
     private boolean nullFromMethods = false;
     private boolean nullFromFields = false;
-    
+
     @Inject @Named(ClassAnalyzer.DEFAULT_IMPLEMENTATION_NAME)
     private ClassAnalyzer delegate;
-    
+
     public void resetToGood() {
         throwFromConstructor = false;
         throwFromMethods = false;
         throwFromFields = false;
         throwFromPostConstruct = false;
         throwFromPreDestroy = false;
-        
+
         nullFromConstructor = false;
         nullFromMethods = false;
         nullFromFields = false;
     }
-    
+
     public void setThrowFromConstructor(boolean throwFromConstructor) {
         this.throwFromConstructor = throwFromConstructor;
     }
@@ -146,7 +146,7 @@ public class ConfigurablyBadClassAnalyzer implements ClassAnalyzer {
         if (throwFromPostConstruct) {
             throw new AssertionError(NegativeClassAnalysisTest.PC_THROW);
         }
-        
+
         return delegate.getPostConstructMethod(clazz);
     }
 
@@ -158,7 +158,7 @@ public class ConfigurablyBadClassAnalyzer implements ClassAnalyzer {
         if (throwFromPreDestroy) {
             throw new AssertionError(NegativeClassAnalysisTest.PD_THROW);
         }
-        
+
         return delegate.getPostConstructMethod(clazz);
     }
 

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/negative/classanalysis/NegativeClassAnalysisModule.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/negative/classanalysis/NegativeClassAnalysisModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,22 +23,23 @@ import org.glassfish.hk2.utilities.BuilderHelper;
 
 /**
  * @author jwells
- *
  */
 public class NegativeClassAnalysisModule implements TestModule {
 
-    /* (non-Javadoc)
-     * @see org.glassfish.hk2.tests.locator.utilities.TestModule#configure(org.glassfish.hk2.api.DynamicConfiguration)
-     */
+    private final String analyzer;
+
+    public NegativeClassAnalysisModule(final String analyzerName) {
+        this.analyzer = analyzerName;
+    }
+
     @Override
     public void configure(DynamicConfiguration config) {
         config.addActiveDescriptor(ConfigurablyBadClassAnalyzer.class);
-        
+
         config.bind(BuilderHelper.link(SelfAnalyzer.class.getName()).
                 to(ClassAnalyzer.class.getName()).
-                analyzeWith(NegativeClassAnalysisTest.SELF_ANALYZER).
+                analyzeWith(this.analyzer).
                 named(NegativeClassAnalysisTest.SELF_ANALYZER).
                 build());
     }
-
 }

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/negative/classanalysis/NegativeClassAnalysisTest.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/negative/classanalysis/NegativeClassAnalysisTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,187 +16,213 @@
 
 package org.glassfish.hk2.tests.locator.negative.classanalysis;
 
-import junit.framework.Assert;
-
 import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.ClassAnalyzer;
+import org.glassfish.hk2.api.DynamicConfiguration;
+import org.glassfish.hk2.api.DynamicConfigurationService;
 import org.glassfish.hk2.api.MultiException;
 import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.api.ServiceLocatorFactory;
 import org.glassfish.hk2.tests.locator.utilities.LocatorHelper;
 import org.glassfish.hk2.utilities.BuilderHelper;
+import org.glassfish.hk2.utilities.IgnoringErrorService;
 import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 /**
  * Negative tests for class analysis
- * 
- * @author jwells
  *
+ * @author jwells
  */
 public class NegativeClassAnalysisTest {
     private final static String TEST_NAME = "NegativeClassAnalysisTest";
-    private final static ServiceLocator locator = LocatorHelper.create(TEST_NAME, new NegativeClassAnalysisModule());
-    
+    private final static ServiceLocator locator = LocatorHelper.create(TEST_NAME,
+        new NegativeClassAnalysisModule(ClassAnalyzer.DEFAULT_IMPLEMENTATION_NAME));
+
     public final static String C_THROW = "Expected throw from constructor";
     public final static String M_THROW = "Expected throw from method";
     public final static String F_THROW = "Expected throw from field";
     public final static String PC_THROW = "Expected throw from pc";
     public final static String PD_THROW = "Expected throw from pd";
-    
+
     public final static String NULL_RETURN = "null return";
     public final static String SELF_ANALYZER = "Narcissus";
-    
+
     @Test
     public void testBadConstructorThrow() {
         ConfigurablyBadClassAnalyzer cbca = locator.getService(ConfigurablyBadClassAnalyzer.class);
         cbca.resetToGood();
-        
+
         cbca.setThrowFromConstructor(true);
         try {
             locator.create(SimpleService.class, ConfigurablyBadClassAnalyzer.BAD_ANALYZER_NAME);
-            Assert.fail("Should have failed due to bad constructor throw");
+            fail("Should have failed due to bad constructor throw");
         }
         catch (MultiException me) {
-            Assert.assertTrue(me.toString().contains(C_THROW));
+            assertThat(me.getMessage(), me.getMessage(), containsString(C_THROW));
         }
-        
+
     }
-    
+
     @Test
     public void testBadMethodThrow() {
         ConfigurablyBadClassAnalyzer cbca = locator.getService(ConfigurablyBadClassAnalyzer.class);
         cbca.resetToGood();
-        
+
         cbca.setThrowFromMethods(true);
         try {
             SimpleService ss = new SimpleService();
             locator.inject(ss, ConfigurablyBadClassAnalyzer.BAD_ANALYZER_NAME);
-            Assert.fail("Should have failed due to bad method throw");
+            fail("Should have failed due to bad method throw");
         }
         catch (MultiException me) {
-            Assert.assertTrue(me.toString().contains(M_THROW));
+            assertThat(me.getMessage(), me.getMessage(), containsString(M_THROW));
         }
-        
+
     }
-    
+
     @Test
     public void testBadFieldThrow() {
         ConfigurablyBadClassAnalyzer cbca = locator.getService(ConfigurablyBadClassAnalyzer.class);
         cbca.resetToGood();
-        
+
         cbca.setThrowFromFields(true);
         try {
             SimpleService ss = new SimpleService();
             locator.inject(ss, ConfigurablyBadClassAnalyzer.BAD_ANALYZER_NAME);
-            Assert.fail("Should have failed due to bad field throw");
+            fail("Should have failed due to bad field throw");
         }
         catch (MultiException me) {
-            Assert.assertTrue(me.toString().contains(F_THROW));
+            assertThat(me.getMessage(), me.getMessage(), containsString(F_THROW));
         }
-        
+
     }
-    
+
     @Test
     public void testBadPCThrow() {
         ConfigurablyBadClassAnalyzer cbca = locator.getService(ConfigurablyBadClassAnalyzer.class);
         cbca.resetToGood();
-        
+
         cbca.setThrowFromPostConstruct(true);
         try {
             SimpleService ss = new SimpleService();
             locator.postConstruct(ss, ConfigurablyBadClassAnalyzer.BAD_ANALYZER_NAME);
-            Assert.fail("Should have failed due to bad pc throw");
+            fail("Should have failed due to bad pc throw");
         }
         catch (MultiException me) {
-            Assert.assertTrue(me.toString().contains(PC_THROW));
+            assertThat(me.getMessage(), me.getMessage(), containsString(PC_THROW));
         }
-        
+
     }
-    
+
     @Test
     public void testBadPDThrow() {
         ConfigurablyBadClassAnalyzer cbca = locator.getService(ConfigurablyBadClassAnalyzer.class);
         cbca.resetToGood();
-        
+
         cbca.setThrowFromPreDestroy(true);
         try {
             SimpleService ss = new SimpleService();
             locator.preDestroy(ss, ConfigurablyBadClassAnalyzer.BAD_ANALYZER_NAME);
-            Assert.fail("Should have failed due to bad pd throw");
+            fail("Should have failed due to bad pd throw");
         }
         catch (MultiException me) {
-            Assert.assertTrue(me.toString(), me.toString().contains(PD_THROW));
+            assertThat(me.toString(), me.toString(), containsString(PD_THROW));
         }
-        
+
     }
-    
+
     @Test
     public void testBadConstructorNull() {
         ConfigurablyBadClassAnalyzer cbca = locator.getService(ConfigurablyBadClassAnalyzer.class);
         cbca.resetToGood();
-        
+
         cbca.setNullFromConstructor(true);
         try {
             locator.create(SimpleService.class, ConfigurablyBadClassAnalyzer.BAD_ANALYZER_NAME);
-            Assert.fail("Should have failed due to null constructor return");
+            fail("Should have failed due to null constructor return");
         }
         catch (MultiException me) {
-            Assert.assertTrue(me.toString().contains("null return"));
+            assertThat(me.getMessage(), me.getMessage(), containsString("null return"));
         }
-        
+
     }
-    
+
     @Test
     public void testBadMethodNull() {
         ConfigurablyBadClassAnalyzer cbca = locator.getService(ConfigurablyBadClassAnalyzer.class);
         cbca.resetToGood();
-        
+
         cbca.setNullFromMethods(true);
         try {
             SimpleService ss = new SimpleService();
             locator.inject(ss, ConfigurablyBadClassAnalyzer.BAD_ANALYZER_NAME);
-            Assert.fail("Should have failed due to null method return");
+            fail("Should have failed due to null method return");
         }
         catch (MultiException me) {
-            Assert.assertTrue(me.toString().contains("null return"));
+            assertThat(me.getMessage(), me.getMessage(), containsString("null return"));
         }
-        
+
     }
-    
+
     @Test
     public void testBadFieldNull() {
         ConfigurablyBadClassAnalyzer cbca = locator.getService(ConfigurablyBadClassAnalyzer.class);
         cbca.resetToGood();
-        
+
         cbca.setNullFromFields(true);
         try {
             SimpleService ss = new SimpleService();
             locator.inject(ss, ConfigurablyBadClassAnalyzer.BAD_ANALYZER_NAME);
-            Assert.fail("Should have failed due to null method return");
+            fail("Should have failed due to null method return");
         }
         catch (MultiException me) {
-            Assert.assertTrue(me.toString().contains("null return"));
+            assertThat(me.getMessage(), me.getMessage(), containsString("null return"));
         }
-        
+
     }
-    
+
+    /**
+     * This test makes sure a class analyzer is not its own analyzer
+     */
+    @Test
+    public void testSelfAnalyzerWithIgnoringExceptions() {
+        final ServiceLocator ownLocator = ServiceLocatorFactory.getInstance()
+            .create(TEST_NAME + "_IllegalIgnoringExceptions");
+        final DynamicConfigurationService dcs = ownLocator.getService(DynamicConfigurationService.class);
+        final DynamicConfiguration cfg = dcs.createDynamicConfiguration();
+        cfg.bind(BuilderHelper.createDescriptorFromClass(IgnoringErrorService.class));
+        cfg.commit();
+
+        final NegativeClassAnalysisModule module = new NegativeClassAnalysisModule(SELF_ANALYZER);
+        DynamicConfiguration cfg2 = dcs.createDynamicConfiguration();
+        module.configure(cfg2);
+        cfg2.commit();
+
+        final ActiveDescriptor<?> selfDescriptor = ownLocator
+            .getBestDescriptor(BuilderHelper.createNameAndContractFilter(ClassAnalyzer.class.getName(), SELF_ANALYZER));
+        assertNotNull(selfDescriptor);
+        try {
+            ownLocator.reifyDescriptor(selfDescriptor);
+            fail("Should have failed, a class may not analyze itself");
+        } catch (MultiException me) {
+            assertThat(me.getMessage(), me.getMessage(), containsString("is its own ClassAnalyzer"));
+        }
+    }
     /**
      * This test makes sure a class analyzer is not its own analyzer
      */
     @Test
     public void testSelfAnalyzer() {
-        ActiveDescriptor<?> selfDescriptor =
-                locator.getBestDescriptor(BuilderHelper.createNameAndContractFilter(
-                        ClassAnalyzer.class.getName(),
-                        SELF_ANALYZER));
-        Assert.assertNotNull(selfDescriptor);
-        
         try {
-            locator.reifyDescriptor(selfDescriptor);
-            Assert.fail("Should have failed, a class may not analyze itself");
-        }
-        catch (MultiException me) {
-            Assert.assertTrue(me.toString().contains("is its own ClassAnalyzer"));
+            LocatorHelper.create(TEST_NAME + "_Illegal", new NegativeClassAnalysisModule(SELF_ANALYZER));
+            fail("Should have failed, a class may not analyze itself");
+        } catch (MultiException me) {
+            assertThat(me.getMessage(), me.getMessage(), containsString("is its own ClassAnalyzer"));
         }
     }
-
 }

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/negative/errorservice1/ErrorService1Test.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/negative/errorservice1/ErrorService1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -30,7 +30,7 @@ import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.tests.locator.utilities.LocatorHelper;
 import org.glassfish.hk2.utilities.BuilderHelper;
 import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
-import org.junit.Assert;;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -39,7 +39,7 @@ import org.junit.Test;
  */
 public class ErrorService1Test {
     public static final String ERROR_STRING = "Expected Exception ErrorService1Test";
-    
+
     /**
      * Tests that a service that fails in the constructor has the error passed to the error service
      */
@@ -47,11 +47,11 @@ public class ErrorService1Test {
     public void testServiceFailsInConstructor() {
         ServiceLocator locator = LocatorHelper.getServiceLocator(RecordingErrorService.class,
                 ServiceFailsInConstructor.class);
-        
+
         ActiveDescriptor<?> serviceDescriptor = locator.getBestDescriptor(BuilderHelper.createContractFilter(
                 ServiceFailsInConstructor.class.getName()));
         Assert.assertNotNull(serviceDescriptor);
-        
+
         try {
             locator.getService(ServiceFailsInConstructor.class);
             Assert.fail("Should have failed");
@@ -59,21 +59,21 @@ public class ErrorService1Test {
         catch (MultiException me) {
             Assert.assertTrue(me.getMessage().contains(ERROR_STRING));
         }
-        
+
         List<ErrorInformation> errors = locator.getService(RecordingErrorService.class).getAndClearErrors();
-        
+
         Assert.assertEquals(1, errors.size());
-        
+
         ErrorInformation ei = errors.get(0);
-        
+
         Assert.assertEquals(ErrorType.SERVICE_CREATION_FAILURE, ei.getErrorType());
         Assert.assertEquals(serviceDescriptor, ei.getDescriptor());
         Assert.assertNull(ei.getInjectee());
-        
+
         Throwable associatedException = ei.getAssociatedException();
         Assert.assertTrue(associatedException.getMessage().contains(ERROR_STRING));
     }
-    
+
     /**
      * Tests that a service that fails in an initializer method has the error passed to the error service
      */
@@ -82,11 +82,11 @@ public class ErrorService1Test {
         ServiceLocator locator = LocatorHelper.getServiceLocator(RecordingErrorService.class,
                 SimpleService.class,
                 ServiceFailsInInitializerMethod.class);
-        
+
         ActiveDescriptor<?> serviceDescriptor = locator.getBestDescriptor(BuilderHelper.createContractFilter(
                 ServiceFailsInInitializerMethod.class.getName()));
         Assert.assertNotNull(serviceDescriptor);
-        
+
         try {
             locator.getService(ServiceFailsInInitializerMethod.class);
             Assert.fail("Should have failed");
@@ -94,21 +94,21 @@ public class ErrorService1Test {
         catch (MultiException me) {
             Assert.assertTrue(me.getMessage().contains(ERROR_STRING));
         }
-        
+
         List<ErrorInformation> errors = locator.getService(RecordingErrorService.class).getAndClearErrors();
-        
+
         Assert.assertEquals(1, errors.size());
-        
+
         ErrorInformation ei = errors.get(0);
-        
+
         Assert.assertEquals(ErrorType.SERVICE_CREATION_FAILURE, ei.getErrorType());
         Assert.assertEquals(serviceDescriptor, ei.getDescriptor());
         Assert.assertNull(ei.getInjectee());
-        
+
         Throwable associatedException = ei.getAssociatedException();
         Assert.assertTrue(associatedException.getMessage().contains(ERROR_STRING));
     }
-    
+
     /**
      * Tests that a service that fails in an postConstruct method has the error passed to the error service
      */
@@ -116,11 +116,11 @@ public class ErrorService1Test {
     public void testServiceFailsInPostConstruct() {
         ServiceLocator locator = LocatorHelper.getServiceLocator(RecordingErrorService.class,
                 ServiceFailsInPostConstruct.class);
-        
+
         ActiveDescriptor<?> serviceDescriptor = locator.getBestDescriptor(BuilderHelper.createContractFilter(
                 ServiceFailsInPostConstruct.class.getName()));
         Assert.assertNotNull(serviceDescriptor);
-        
+
         try {
             locator.getService(ServiceFailsInPostConstruct.class);
             Assert.fail("Should have failed");
@@ -128,39 +128,39 @@ public class ErrorService1Test {
         catch (MultiException me) {
             Assert.assertTrue(me.getMessage().contains(ERROR_STRING));
         }
-        
+
         List<ErrorInformation> errors = locator.getService(RecordingErrorService.class).getAndClearErrors();
-        
+
         Assert.assertEquals(1, errors.size());
-        
+
         ErrorInformation ei = errors.get(0);
-        
+
         Assert.assertEquals(ErrorType.SERVICE_CREATION_FAILURE, ei.getErrorType());
         Assert.assertEquals(serviceDescriptor, ei.getDescriptor());
         Assert.assertNull(ei.getInjectee());
-        
+
         Throwable associatedException = ei.getAssociatedException();
         Assert.assertTrue(associatedException.getMessage().contains(ERROR_STRING));
     }
-    
+
     /**
      * Tests that a service that comes from a factory that fails in provide
      */
     @Test
     public void testFactorServiceFailsInProvide() {
         ServiceLocator locator = LocatorHelper.getServiceLocator(RecordingErrorService.class);
-        
+
         FactoryDescriptors fds = BuilderHelper.link(FactoryFailsInProvideService.class)
                      .to(SimpleService.class.getName())
                      .in(Singleton.class.getName())
                      .buildFactory(Singleton.class.getName());
-        
+
         ServiceLocatorUtilities.addFactoryDescriptors(locator, fds);
-        
+
         ActiveDescriptor<?> serviceDescriptor = locator.getBestDescriptor(BuilderHelper.createContractFilter(
                 SimpleService.class.getName()));
         Assert.assertNotNull(serviceDescriptor);
-        
+
         try {
             locator.getService(SimpleService.class);
             Assert.fail("Should have failed");
@@ -168,21 +168,21 @@ public class ErrorService1Test {
         catch (MultiException me) {
             Assert.assertTrue(me.getMessage().contains(ERROR_STRING));
         }
-        
+
         List<ErrorInformation> errors = locator.getService(RecordingErrorService.class).getAndClearErrors();
-        
+
         Assert.assertEquals(1, errors.size());
-        
+
         ErrorInformation ei = errors.get(0);
-        
+
         Assert.assertEquals(ErrorType.SERVICE_CREATION_FAILURE, ei.getErrorType());
         Assert.assertEquals(serviceDescriptor, ei.getDescriptor());
         Assert.assertNull(ei.getInjectee());
-        
+
         Throwable associatedException = ei.getAssociatedException();
         Assert.assertTrue(associatedException.getMessage().contains(ERROR_STRING));
     }
-    
+
     /**
      * Tests that a service that fails but tells HK2 to NOT report the failure to the error handler service
      */
@@ -190,11 +190,11 @@ public class ErrorService1Test {
     public void testSilentFailureInPostConstruct() {
         ServiceLocator locator = LocatorHelper.getServiceLocator(RecordingErrorService.class,
                 ServiceDirectsNoErrorService.class);
-        
+
         ActiveDescriptor<?> serviceDescriptor = locator.getBestDescriptor(BuilderHelper.createContractFilter(
                 ServiceDirectsNoErrorService.class.getName()));
         Assert.assertNotNull(serviceDescriptor);
-        
+
         try {
             locator.getService(ServiceDirectsNoErrorService.class);
             Assert.fail("Should have failed");
@@ -202,27 +202,27 @@ public class ErrorService1Test {
         catch (MultiException me) {
             Assert.assertTrue(me.getMessage().contains(ERROR_STRING));
         }
-        
+
         List<ErrorInformation> errors = locator.getService(RecordingErrorService.class).getAndClearErrors();
-        
+
         Assert.assertEquals(0, errors.size());
     }
-    
+
     /**
      * Tests that a third-party service that fails in create
      */
     @Test
     public void testFailingThirdPartyService() {
         ServiceLocator locator = LocatorHelper.getServiceLocator(RecordingErrorService.class);
-        
+
         AlwaysFailActiveDescriptor thirdPartyDescriptor = new AlwaysFailActiveDescriptor();
-        
+
         ServiceLocatorUtilities.addOneDescriptor(locator, thirdPartyDescriptor);
-        
+
         ActiveDescriptor<?> serviceDescriptor = locator.getBestDescriptor(BuilderHelper.createContractFilter(
                 SimpleService.class.getName()));
         Assert.assertNotNull(serviceDescriptor);
-        
+
         try {
             locator.getService(SimpleService.class);
             Assert.fail("Should have failed");
@@ -230,21 +230,21 @@ public class ErrorService1Test {
         catch (MultiException me) {
             Assert.assertTrue(me.getMessage().contains(ERROR_STRING));
         }
-        
+
         List<ErrorInformation> errors = locator.getService(RecordingErrorService.class).getAndClearErrors();
-        
+
         Assert.assertEquals(1, errors.size());
-        
+
         ErrorInformation ei = errors.get(0);
-        
+
         Assert.assertEquals(ErrorType.SERVICE_CREATION_FAILURE, ei.getErrorType());
         Assert.assertEquals(serviceDescriptor, ei.getDescriptor());
         Assert.assertNull(ei.getInjectee());
-        
+
         Throwable associatedException = ei.getAssociatedException();
         Assert.assertTrue(associatedException.getMessage().contains(ERROR_STRING));
     }
-    
+
     /**
      * Tests that a service that fails during destruction is reported to the error service
      */
@@ -252,97 +252,97 @@ public class ErrorService1Test {
     public void testFailsInDestroy() {
         ServiceLocator locator = LocatorHelper.getServiceLocator(RecordingErrorService.class,
                 ServiceFailsInDestructor.class);
-        
+
         ActiveDescriptor<?> serviceDescriptor = locator.getBestDescriptor(BuilderHelper.createContractFilter(
                 ServiceFailsInDestructor.class.getName()));
         Assert.assertNotNull(serviceDescriptor);
-        
+
         try (ServiceHandle<ServiceFailsInDestructor> handle = locator.getServiceHandle(ServiceFailsInDestructor.class)) {
             Assert.assertNotNull(handle.getService());
         }
-        
+
         List<ErrorInformation> errors = locator.getService(RecordingErrorService.class).getAndClearErrors();
-        
+
         Assert.assertEquals(1, errors.size());
-        
+
         ErrorInformation ei = errors.get(0);
-        
+
         Assert.assertEquals(ErrorType.SERVICE_DESTRUCTION_FAILURE, ei.getErrorType());
         Assert.assertEquals(serviceDescriptor, ei.getDescriptor());
         Assert.assertNull(ei.getInjectee());
-        
+
         Throwable associatedException = ei.getAssociatedException();
         Assert.assertTrue(associatedException.getMessage().contains(ERROR_STRING));
     }
-    
+
     /**
      * Tests that a service that is created by a factory where the factory dispose method fails
      */
     @Test
     public void testFactorServiceFailsInDispose() {
         ServiceLocator locator = LocatorHelper.getServiceLocator(RecordingErrorService.class);
-        
+
         FactoryDescriptors fds = BuilderHelper.link(FactoryFailsInDisposeService.class)
                      .to(SimpleService.class.getName())
                      .in(Singleton.class.getName())
                      .buildFactory(Singleton.class.getName());
-        
+
         ServiceLocatorUtilities.addFactoryDescriptors(locator, fds);
-        
+
         ActiveDescriptor<?> serviceDescriptor = locator.getBestDescriptor(BuilderHelper.createContractFilter(
                 SimpleService.class.getName()));
         Assert.assertNotNull(serviceDescriptor);
-        
+
         try (ServiceHandle<SimpleService> handle = locator.getServiceHandle(SimpleService.class)) {
             Assert.assertNotNull(handle);
             Assert.assertNotNull(handle.getService());
         }
-        
+
         List<ErrorInformation> errors = locator.getService(RecordingErrorService.class).getAndClearErrors();
-        
+
         Assert.assertEquals(1, errors.size());
-        
+
         ErrorInformation ei = errors.get(0);
-        
+
         Assert.assertEquals(ErrorType.SERVICE_DESTRUCTION_FAILURE, ei.getErrorType());
         Assert.assertEquals(serviceDescriptor, ei.getDescriptor());
         Assert.assertNull(ei.getInjectee());
-        
+
         Throwable associatedException = ei.getAssociatedException();
         Assert.assertTrue(associatedException.getMessage().contains(ERROR_STRING));
     }
-    
+
     /**
      * Tests that a third-party service that fails in dispose
      */
     @Test
     public void testFailingInDisposeThirdPartyService() {
         ServiceLocator locator = LocatorHelper.getServiceLocator(RecordingErrorService.class);
-        
+
         AlwaysFailInDisposeActiveDescriptor thirdPartyDescriptor = new AlwaysFailInDisposeActiveDescriptor();
-        
+
         ServiceLocatorUtilities.addOneDescriptor(locator, thirdPartyDescriptor);
-        
+
         ActiveDescriptor<?> serviceDescriptor = locator.getBestDescriptor(BuilderHelper.createContractFilter(
                 SimpleService.class.getName()));
         Assert.assertNotNull(serviceDescriptor);
-        
+
         ServiceHandle<SimpleService> handle = locator.getServiceHandle(SimpleService.class);
         Assert.assertNotNull(handle);
         Assert.assertNotNull(handle.getService());
-        
+
         handle.destroy();
-        
+
         List<ErrorInformation> errors = locator.getService(RecordingErrorService.class).getAndClearErrors();
-        
+
         Assert.assertEquals(1, errors.size());
-        
+
         ErrorInformation ei = errors.get(0);
-        
+
         Assert.assertEquals(ErrorType.SERVICE_DESTRUCTION_FAILURE, ei.getErrorType());
         Assert.assertEquals(serviceDescriptor, ei.getDescriptor());
         Assert.assertNull(ei.getInjectee());
-        
+
         Throwable associatedException = ei.getAssociatedException();
         Assert.assertTrue(associatedException.getMessage().contains(ERROR_STRING));
     }

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/negative/factory/BadlyNamedFactory.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/negative/factory/BadlyNamedFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,21 +20,22 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.api.PerLookup;
 
 /**
  * This factory has a provide method with a {@link Named}
  * annotation with no value, which is illegal
- * 
+ *
  * @author jwells
  *
  */
-@Singleton
+@PerLookup
 public class BadlyNamedFactory implements Factory<SimpleService2> {
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.api.Factory#provide()
      */
-    @Override @Singleton @Named
+    @Override @Singleton @Named // this is missing: ("SomeName")
     public SimpleService2 provide() {
         throw new AssertionError("not called");
     }
@@ -45,7 +46,7 @@ public class BadlyNamedFactory implements Factory<SimpleService2> {
     @Override
     public void dispose(SimpleService2 instance) {
         throw new AssertionError("not called");
-        
+
     }
 
 }

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/negative/factory/NegativeFactoryTest.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/negative/factory/NegativeFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,43 +16,41 @@
 
 package org.glassfish.hk2.tests.locator.negative.factory;
 
-import junit.framework.Assert;
-
 import org.glassfish.hk2.api.MultiException;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.tests.locator.utilities.LocatorHelper;
 import org.glassfish.hk2.utilities.BuilderHelper;
 import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
-import org.junit.Ignore;
 import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.fail;
 
 /**
  * @author jwells
- *
  */
 public class NegativeFactoryTest {
     private final static String TEST_NAME = "NegativeFactoryTest";
     private final static ServiceLocator locator = LocatorHelper.create(TEST_NAME, new NegativeFactoryModule());
-    
+
     /* package */ final static String THROW_STRING = "Expected thrown exception";
-    
+
     /**
      * Factories cannot have a Named annation with no value
      */
     @Test
     public void testFactoryWithBadName() {
         try {
-            locator.reifyDescriptor(locator.getBestDescriptor(BuilderHelper.createContractFilter(
-                    SimpleService2.class.getName())));
-            Assert.fail("The SimpleService2 factory has a bad name and so is invalid");
+            locator.reifyDescriptor(
+                locator.getBestDescriptor(BuilderHelper.createContractFilter(SimpleService2.class.getName())));
+            fail("The SimpleService2 factory has a bad name and so is invalid");
+        } catch (MultiException me) {
+            assertThat(me.getMessage(), me.getMessage(),
+                containsString("@Named on the provide method of a factory must have an explicit value"));
         }
-        catch (MultiException me) {
-            Assert.assertTrue(me.getMessage(), me.getMessage().contains(
-                    "@Named on the provide method of a factory must have an explicit value"));
-        }
-        
     }
-    
+
     /**
      * Ensures that a factory producing for the singleton scope works properly
      */
@@ -60,13 +58,12 @@ public class NegativeFactoryTest {
     public void testFactoryThatThrowsInSingletonScope() {
         try {
             locator.getService(SimpleService.class);
-            Assert.fail("The factory throws an exception, so should not have gotten here");
-        }
-        catch (MultiException me) {
-            Assert.assertTrue(me.getMessage().contains(THROW_STRING));
+            fail("The factory throws an exception, so should not have gotten here");
+        } catch (MultiException me) {
+            assertThat(me.getMessage(), me.getMessage(), containsString(THROW_STRING));
         }
     }
-    
+
     /**
      * Ensures that a factory producing for the per lookup scope works properly
      */
@@ -74,64 +71,57 @@ public class NegativeFactoryTest {
     public void testFactoryThatThrowsInPerLookupScope() {
         try {
             locator.getService(SimpleService3.class);
-            Assert.fail("The factory throws an exception, so should not have gotten here");
-        }
-        catch (MultiException me) {
-            Assert.assertTrue(me.getMessage().contains(THROW_STRING));
+            fail("The factory throws an exception, so should not have gotten here");
+        } catch (MultiException me) {
+            assertThat(me.getMessage(), me.getMessage(), containsString(THROW_STRING));
         }
     }
-    
+
     /**
      * Ensures that a factory producing for the per thread scope works properly
      */
     @Test
     public void testFactoryThatThrowsInPerThreadScope() {
         ServiceLocatorUtilities.enablePerThreadScope(locator);
-        
+
         try {
             locator.getService(SimpleService4.class);
-            Assert.fail("The factory throws an exception, so should not have gotten here");
-        }
-        catch (MultiException me) {
-            Assert.assertTrue(me.getMessage().contains(THROW_STRING));
+            fail("The factory throws an exception, so should not have gotten here");
+        } catch (MultiException me) {
+            assertThat(me.getMessage(), me.getMessage(), containsString(THROW_STRING));
         }
     }
-    
+
     /**
      * Ensures that a factory producing for the immediate scope works properly
      */
     @Test
     public void testFactoryThatThrowsInImmediateScope() {
         ServiceLocatorUtilities.enableImmediateScope(locator);
-        
         try {
             locator.getService(SimpleService5.class);
-            Assert.fail("The factory throws an exception, so should not have gotten here");
-        }
-        catch (MultiException me) {
-            Assert.assertTrue(me.getMessage().contains(THROW_STRING));
+            fail("The factory throws an exception, so should not have gotten here");
+        } catch (MultiException me) {
+            assertThat(me.getMessage(), me.getMessage(), containsString(THROW_STRING));
         }
     }
-    
+
     /**
      * Tests that a PerLookup factory depending on itself will notice
      * the infinite problem and throw an exception
      */
-    @Test // @org.junit.Ignore
+    @Test
     public void testInfiniteLoopPerLookupFactory() {
-        ServiceLocator locator = LocatorHelper.create();
-        ServiceLocatorUtilities.addClasses(locator, InfiniteFactory.class);
-        
+        ServiceLocator ownLocator = LocatorHelper.create();
+        ServiceLocatorUtilities.addClasses(ownLocator, InfiniteFactory.class);
         try {
-          locator.getService(SimpleService5.class);
-          Assert.fail("Should have failed due to recursion");
+          ownLocator.getService(SimpleService5.class);
+          fail("Should have failed due to recursion");
+        } catch (MultiException me) {
+            assertThat(me.getMessage(), me.getMessage(), containsString("A cycle was detected"));
+            assertThat(me.getMessage(), me.getMessage(), containsString(InfiniteFactory.class.getName()));
         }
-        catch (MultiException me) {
-            // Success
-            Assert.assertTrue(me.getMessage().contains("A cycle was detected"));
-            Assert.assertTrue(me.getMessage().contains(InfiniteFactory.class.getName()));
-        }
-        
+
     }
 
 }

--- a/hk2-testing/hk2-testng/src/main/java/org/jvnet/testing/hk2testng/HK2TestListenerAdapter.java
+++ b/hk2-testing/hk2-testng/src/main/java/org/jvnet/testing/hk2testng/HK2TestListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,10 +19,14 @@ package org.jvnet.testing.hk2testng;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.glassfish.hk2.api.DynamicConfiguration;
+import org.glassfish.hk2.api.DynamicConfigurationService;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.api.ServiceLocatorFactory;
 import org.glassfish.hk2.extras.ExtrasUtilities;
 import org.glassfish.hk2.utilities.Binder;
+import org.glassfish.hk2.utilities.BuilderHelper;
+import org.glassfish.hk2.utilities.IgnoringErrorService;
 import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
 import org.testng.IConfigurable;
 import org.testng.IConfigureCallBack;
@@ -37,9 +41,9 @@ import org.testng.ITestResult;
  */
 public class HK2TestListenerAdapter implements IExecutionListener, IHookable, IConfigurable {
 
-    private static final Map<String, ServiceLocator> serviceLocators = new ConcurrentHashMap<String, ServiceLocator>();
-    private static final Map<Class<?>, Object> testClasses = new ConcurrentHashMap<Class<?>, Object>();
-    private static final Map<Class<?>, Binder> binderClasses = new ConcurrentHashMap<Class<?>, Binder>();
+    private static final Map<String, ServiceLocator> serviceLocators = new ConcurrentHashMap<>();
+    private static final Map<Class<?>, Object> testClasses = new ConcurrentHashMap<>();
+    private static final Map<Class<?>, Binder> binderClasses = new ConcurrentHashMap<>();
 
     @Override
     public void onExecutionStart() {
@@ -95,6 +99,11 @@ public class HK2TestListenerAdapter implements IExecutionListener, IHookable, IC
 
       if (hk2.enableLookupExceptions()) {
         ServiceLocatorUtilities.enableLookupExceptions(locator);
+      } else {
+          final DynamicConfigurationService dcs = locator.getService(DynamicConfigurationService.class);
+          final DynamicConfiguration cfg = dcs.createDynamicConfiguration();
+          cfg.bind(BuilderHelper.createDescriptorFromClass(IgnoringErrorService.class));
+          cfg.commit();
       }
 
       if (hk2.enableEvents()) {


### PR DESCRIPTION
The main difference in behavior is this:

**Original**

1. Invoke creation of a ServiceLocator (usually via some ModulesRegistry implementation)
2. If there is a problem, you will not know about it, you will receive a ServiceLocator which may or may not work. Trying to access DynamicConfigurationService may endup with NPE/ISE as in https://github.com/eclipse-ee4j/glassfish-hk2/issues/464 but you will not get real cause.
3. If there is not a problem, you will receive a ServiceLocator instance. You can reconfigure it or use it, whatever.

**Now**

1. Invoke creation of a ServiceLocator (usually via some ModulesRegistry implementation)
2. If there is a problem, it will cause an exception. Deal with it.
3. If there is not a problem, you will receive a ServiceLocator instance. You can reconfigure it or use it, whatever.

- originally ServiceLocator initialization ignored all errors, so when the DynamicConfigurationService  was not accessible because of classloading issues (on JDK11), it ended up with NPE without any usable information about the cause (not even in configured logs).

- now the original behavior can be reached by configuring the IgnoringErrorService, but creation of ServiceLocator would throw exception if it could not be instantiated.

- initialization is sucessful and the service is configured OR you catch an exception, but you should not get unconfigured failing locator.
