### PR TITLE
FISH-1282 Jakarta EE9: Fixes HK2 OSGI issues on starting the Payara Server

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -28,7 +28,7 @@
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-bom</artifactId>
-    <version>3.0.1</version>
+    <version>3.0.1.payara-p1</version>
     <packaging>pom</packaging>
 
     <name>HK2 Bom Pom</name>

--- a/class-model/pom.xml
+++ b/class-model/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/MethodModel.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/MethodModel.java
@@ -48,6 +48,12 @@ public interface MethodModel extends Member, AnnotatedElement {
     String[] getArgumentTypes();
 
     /**
+     * @return the checked exception types, or an empty array if the method doesn't
+     *         declare any thrown exceptions
+     */
+    String[] getExceptionTypes();
+
+    /**
      * Returns the list of parameter
      *
      * @return the list of parameter

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/MethodModelImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/MethodModelImpl.java
@@ -26,6 +26,7 @@ import java.util.List;
 public class MethodModelImpl extends AnnotatedElementImpl implements MethodModel {
 
     private List<Parameter> parameters;
+    private List<ParameterizedType> exceptionTypes;
     private ParameterizedType returnType;
     final ExtensibleType<?> owner;
     private final String signature;
@@ -72,6 +73,24 @@ public class MethodModelImpl extends AnnotatedElementImpl implements MethodModel
             stringTypes = new String[0];
         }
         return stringTypes;
+    }
+
+    @Override
+    public String[] getExceptionTypes() {
+        String[] stringTypes;
+        if (exceptionTypes != null) {
+            stringTypes = new String[exceptionTypes.size()];
+            for (int i = 0; i < exceptionTypes.size(); i++) {
+                stringTypes[i] = exceptionTypes.get(i).getTypeName();
+            }
+        } else {
+            stringTypes = new String[0];
+        }
+        return stringTypes;
+    }
+
+    public void setExceptionTypes(List<ParameterizedType> exceptionTypes) {
+        this.exceptionTypes = exceptionTypes;
     }
 
     @Override

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/MethodSignatureVisitorImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/MethodSignatureVisitorImpl.java
@@ -35,6 +35,7 @@ public class MethodSignatureVisitorImpl extends SignatureVisitor {
     private final MethodModel methodModel;
 
     private final List<Parameter> parameters = new ArrayList<>();
+    private final List<ParameterizedType> exceptionTypes = new ArrayList<>();
     private final ParameterizedType returnType = new ParameterizedTypeImpl();
     private final ArrayDeque<ParameterizedType> parentType = new ArrayDeque<>();
 
@@ -49,6 +50,10 @@ public class MethodSignatureVisitorImpl extends SignatureVisitor {
         return parameters;
     }
 
+    public List<ParameterizedType> getExceptionTypes() {
+        return exceptionTypes;
+    }
+
     public ParameterizedType getReturnType() {
         return returnType;
     }
@@ -58,6 +63,11 @@ public class MethodSignatureVisitorImpl extends SignatureVisitor {
         ParameterImpl parameter = new ParameterImpl(parameters.size(), null, methodModel);
         parameters.add(parameter);
         parentType.add(parameter);
+        return this;
+    }
+
+    @Override
+    public SignatureVisitor visitExceptionType() {
         return this;
     }
 

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ModelClassVisitor.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ModelClassVisitor.java
@@ -280,6 +280,17 @@ public class ModelClassVisitor extends ClassVisitor {
         org.objectweb.asm.Type type = org.objectweb.asm.Type.getReturnType(desc);
         returnType.setType(type);
 
+        final List<ParameterizedType> exceptionTypes = new ArrayList<>();
+        if (exceptions != null) {
+            for (int i = 0; i < exceptions.length; i++) {
+                final String exception = exceptions[i];
+                final ParameterizedTypeImpl exceptionType = new ParameterizedTypeImpl(exception);
+                exceptionType.setType(org.objectweb.asm.Type.getObjectType(exception));
+                exceptionTypes.add(exceptionType);
+            }
+        }
+        methodModel.setExceptionTypes(exceptionTypes);
+
         org.objectweb.asm.Type[] types = org.objectweb.asm.Type.getArgumentTypes(desc);
         for (int i = 0; i < methodModel.getParameters().size(); i++) {
             ParameterImpl parameter = (ParameterImpl) methodModel.getParameter(i);

--- a/class-model/src/test/java/org/glassfish/hk2/classmodel/reflect/test/method/MethodTest.java
+++ b/class-model/src/test/java/org/glassfish/hk2/classmodel/reflect/test/method/MethodTest.java
@@ -82,6 +82,11 @@ public class MethodTest {
                         Assert.assertEquals("yellow", gradientColor2.get(0).getValues().get("name"));
                         Assert.assertEquals("orange", gradientColor2.get(1).getValues().get("name"));
 
+                        // Exception types
+                        final String[] exceptionTypes = mm.getExceptionTypes();
+                        Assert.assertEquals(1, exceptionTypes.length);
+                        Assert.assertEquals(IllegalArgumentException.class.getName(), exceptionTypes[0]);
+
                         // Parameter annotations, type and generic types check
                         Assert.assertEquals(5, mm.getParameters().size());
 

--- a/class-model/src/test/java/org/glassfish/hk2/classmodel/reflect/test/method/SimpleAnnotatedMethod.java
+++ b/class-model/src/test/java/org/glassfish/hk2/classmodel/reflect/test/method/SimpleAnnotatedMethod.java
@@ -44,7 +44,7 @@ public class SimpleAnnotatedMethod {
             List<String> input,
             SampleType<Double, String, SampleType<Short, Float, Long>> sampleType,
             int count,
-            Object value) {
+            Object value) throws IllegalArgumentException {
         return null;
     }
 }

--- a/examples/caching/pom.xml
+++ b/examples/caching/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/examples/caching/runner/pom.xml
+++ b/examples/caching/runner/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>caching-aop-example</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <artifactId>caching-aop-example-runner</artifactId>

--- a/examples/caching/system/pom.xml
+++ b/examples/caching/system/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>caching-aop-example</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <artifactId>caching-aop-example-system</artifactId>

--- a/examples/configuration/pom.xml
+++ b/examples/configuration/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/examples/configuration/webserver/pom.xml
+++ b/examples/configuration/webserver/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>configuration-examples</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <artifactId>webserver-configuration-example</artifactId>

--- a/examples/configuration/xml/pom.xml
+++ b/examples/configuration/xml/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>configuration-examples</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <artifactId>xml-configuration-example</artifactId>

--- a/examples/custom-resolver/pom.xml
+++ b/examples/custom-resolver/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <artifactId>custom-resolver-example</artifactId>
     <name>Custom Resolver Example</name>

--- a/examples/events/pom.xml
+++ b/examples/events/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/examples/events/threaded/pom.xml
+++ b/examples/events/threaded/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>event-examples</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <artifactId>threading-event-example</artifactId>

--- a/examples/operations/pom.xml
+++ b/examples/operations/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <artifactId>operations-example</artifactId>
     <name>Operations Example</name>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/examples/security-lockdown/alice/pom.xml
+++ b/examples/security-lockdown/alice/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>security-lockdown-example</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <artifactId>security-lockdown-example-alice</artifactId>

--- a/examples/security-lockdown/mallory/pom.xml
+++ b/examples/security-lockdown/mallory/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>security-lockdown-example</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <artifactId>security-lockdown-example-mallory</artifactId>

--- a/examples/security-lockdown/pom.xml
+++ b/examples/security-lockdown/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/examples/security-lockdown/runner/pom.xml
+++ b/examples/security-lockdown/runner/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>security-lockdown-example</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <artifactId>security-lockdown-example-runner</artifactId>

--- a/examples/security-lockdown/system/pom.xml
+++ b/examples/security-lockdown/system/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>security-lockdown-example</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <artifactId>security-lockdown-example-system</artifactId>

--- a/external/aopalliance/pom.xml
+++ b/external/aopalliance/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>external</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <groupId>org.glassfish.hk2.external</groupId>
     <artifactId>aopalliance-repackaged</artifactId>

--- a/external/pom.xml
+++ b/external/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/guice-bridge/pom.xml
+++ b/guice-bridge/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>guice-bridge</artifactId>

--- a/hk2-api/pom.xml
+++ b/hk2-api/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-api</artifactId>

--- a/hk2-configuration/hk2-integration/pom.xml
+++ b/hk2-configuration/hk2-integration/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-configuration</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <artifactId>hk2-configuration-integration</artifactId>

--- a/hk2-configuration/manager/pom.xml
+++ b/hk2-configuration/manager/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-configuration</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <artifactId>hk2-configuration-hub</artifactId>

--- a/hk2-configuration/persistence/hk2-xml/hk2-json/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/hk2-json/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <artifactId>hk2-json</artifactId>
     

--- a/hk2-configuration/persistence/hk2-xml/hk2-pbuf/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/hk2-pbuf/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <artifactId>hk2-pbuf</artifactId>
     

--- a/hk2-configuration/persistence/hk2-xml/integration-test/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/integration-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <artifactId>hk2-xml-integration-test</artifactId>
     

--- a/hk2-configuration/persistence/hk2-xml/main/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/main/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <artifactId>hk2-xml</artifactId>
     

--- a/hk2-configuration/persistence/hk2-xml/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-configuration-persistence</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/hk2-configuration/persistence/hk2-xml/schema/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/schema/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <artifactId>hk2-xml-schema</artifactId>
     

--- a/hk2-configuration/persistence/hk2-xml/test1/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/test1/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <artifactId>hk2-xml-test</artifactId>
     

--- a/hk2-configuration/persistence/pom.xml
+++ b/hk2-configuration/persistence/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-configuration</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/hk2-configuration/persistence/property-file/pom.xml
+++ b/hk2-configuration/persistence/property-file/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-configuration-persistence</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <artifactId>hk2-property-file</artifactId>
     

--- a/hk2-configuration/pom.xml
+++ b/hk2-configuration/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/hk2-core/pom.xml
+++ b/hk2-core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <artifactId>hk2-core</artifactId>
     <name>HK2 core module</name>

--- a/hk2-extras/pom.xml
+++ b/hk2-extras/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-extras</artifactId>

--- a/hk2-jmx/pom.xml
+++ b/hk2-jmx/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-jmx</artifactId>

--- a/hk2-locator/pom.xml
+++ b/hk2-locator/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <artifactId>hk2-locator</artifactId>
     <name>ServiceLocator Default Implementation</name>

--- a/hk2-metadata-generator/main/pom.xml
+++ b/hk2-metadata-generator/main/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-metadata-generator-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/hk2-metadata-generator/pom.xml
+++ b/hk2-metadata-generator/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/hk2-metadata-generator/test1/pom.xml
+++ b/hk2-metadata-generator/test1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-metadata-generator-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-metadata-generator-test1</artifactId>

--- a/hk2-runlevel/pom.xml
+++ b/hk2-runlevel/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <artifactId>hk2-runlevel</artifactId>

--- a/hk2-testing/ant/pom.xml
+++ b/hk2-testing/ant/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     

--- a/hk2-testing/collections/pom.xml
+++ b/hk2-testing/collections/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-testing</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <artifactId>hk2-collections-tests</artifactId>

--- a/hk2-testing/hk2-junitrunner/pom.xml
+++ b/hk2-testing/hk2-junitrunner/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>hk2-junitrunner</artifactId>

--- a/hk2-testing/hk2-locator-extras/pom.xml
+++ b/hk2-testing/hk2-locator-extras/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>hk2-locator-extras</artifactId>

--- a/hk2-testing/hk2-locator-no-proxies/pom.xml
+++ b/hk2-testing/hk2-locator-no-proxies/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>hk2-locator-no-proxies</artifactId>

--- a/hk2-testing/hk2-locator-no-proxies2/pom.xml
+++ b/hk2-testing/hk2-locator-no-proxies2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/hk2-mockito/pom.xml
+++ b/hk2-testing/hk2-mockito/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-testing</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <artifactId>hk2-mockito</artifactId>
     <name>HK2 Mockito</name>

--- a/hk2-testing/hk2-runlevel-extras/pom.xml
+++ b/hk2-testing/hk2-runlevel-extras/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>hk2-runlevel-extras</artifactId>

--- a/hk2-testing/hk2-testng/pom.xml
+++ b/hk2-testing/hk2-testng/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>hk2-testng</artifactId>

--- a/hk2-testing/interceptor-events/pom.xml
+++ b/hk2-testing/interceptor-events/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-testing</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <artifactId>interceptor-events</artifactId>

--- a/hk2-testing/jersey/jersey-guice/form-param/pom.xml
+++ b/hk2-testing/jersey/jersey-guice/form-param/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/jersey/jersey-guice/pom.xml
+++ b/hk2-testing/jersey/jersey-guice/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/jersey/pom.xml
+++ b/hk2-testing/jersey/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/pom.xml
+++ b/hk2-testing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/hk2-utils/pom.xml
+++ b/hk2-utils/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-utils</artifactId>

--- a/hk2/pom.xml
+++ b/hk2/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>hk2</artifactId>

--- a/javadocs/pom.xml
+++ b/javadocs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <artifactId>hk2-javadocs</artifactId>
     <name>HK2 Javadocs</name>

--- a/maven-plugins/consolidatedbundle-maven-plugin/pom.xml
+++ b/maven-plugins/consolidatedbundle-maven-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>maven-plugins</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <artifactId>consolidatedbundle-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>

--- a/maven-plugins/hk2-inhabitant-generator/pom.xml
+++ b/maven-plugins/hk2-inhabitant-generator/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>maven-plugins</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <artifactId>hk2-inhabitant-generator</artifactId>
     <packaging>maven-plugin</packaging>

--- a/maven-plugins/osgiversion-maven-plugin/pom.xml
+++ b/maven-plugins/osgiversion-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>maven-plugins</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <artifactId>osgiversion-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>

--- a/maven-plugins/pom.xml
+++ b/maven-plugins/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <artifactId>maven-plugins</artifactId>
     <packaging>pom</packaging>

--- a/osgi/adapter-tests/contract-bundle/pom.xml
+++ b/osgi/adapter-tests/contract-bundle/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <artifactId>contract-bundle</artifactId>

--- a/osgi/adapter-tests/faux-sdp-bundle/pom.xml
+++ b/osgi/adapter-tests/faux-sdp-bundle/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <artifactId>faux-sdp-bundle</artifactId>

--- a/osgi/adapter-tests/no-hk2-bundle/pom.xml
+++ b/osgi/adapter-tests/no-hk2-bundle/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <artifactId>no-hk2-bundle</artifactId>

--- a/osgi/adapter-tests/osgi-adapter-test/pom.xml
+++ b/osgi/adapter-tests/osgi-adapter-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>osgi-adapter-test</artifactId>

--- a/osgi/adapter-tests/pom.xml
+++ b/osgi/adapter-tests/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/osgi/adapter-tests/sdp-management-bundle/pom.xml
+++ b/osgi/adapter-tests/sdp-management-bundle/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <artifactId>sdp-management-bundle</artifactId>

--- a/osgi/adapter-tests/test-module-startup/pom.xml
+++ b/osgi/adapter-tests/test-module-startup/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
 
     <artifactId>test-module-startup</artifactId>

--- a/osgi/adapter/pom.xml
+++ b/osgi/adapter/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <artifactId>osgi-adapter</artifactId>
     <name>HK2 OSGi Adapter</name>

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>osgi</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-parent</artifactId>
-    <version>3.0.1</version>
+    <version>3.0.1.payara-p1</version>
     <packaging>pom</packaging>
 
     <name>GlassFish HK2</name>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <jtype.version>0.1.3</jtype.version>
         <javassist.version>3.22.0-GA</javassist.version>
         <junit.version>4.13.1</junit.version>
-        <asm.version>7.3.1</asm.version>
+        <asm.version>9.1</asm.version>
         <woodstox.version>4.1.2</woodstox.version>
         <stax-api.version>1.0-2</stax-api.version>
         <aopalliance.version>1.0</aopalliance.version>

--- a/spring-bridge/pom.xml
+++ b/spring-bridge/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.payara-p1</version>
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>spring-bridge</artifactId>


### PR DESCRIPTION
This PR fixes the OSGI issue by upgrading the ASM version and also cherry-picked the missed commit from 2.6.x branch.