### PR TITLE
[FISH-1083] Consistent null-checking for typeProxy

### DIFF
--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/FieldModelImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/FieldModelImpl.java
@@ -57,7 +57,10 @@ public class FieldModelImpl extends AnnotatedElementImpl implements FieldModel {
 
     @Override
     public String getDeclaringTypeName() {
-        return typeProxy.getName();
+        if (typeProxy != null) {
+            return typeProxy.getName();
+        }
+        return null;
     }
 
     @Override

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ParameterImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ParameterImpl.java
@@ -60,7 +60,11 @@ public class ParameterImpl extends AnnotatedElementImpl implements Parameter {
 
     @Override
     public Type getType() {
-        return typeProxy.get();
+        if (typeProxy != null) {
+          return typeProxy.get();
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/class-model/src/test/java/org/glassfish/hk2/classmodel/reflect/test/ClassModelTestsUtils.java
+++ b/class-model/src/test/java/org/glassfish/hk2/classmodel/reflect/test/ClassModelTestsUtils.java
@@ -18,7 +18,6 @@ package org.glassfish.hk2.classmodel.reflect.test;
 
 import org.glassfish.hk2.classmodel.reflect.Parser;
 import org.glassfish.hk2.classmodel.reflect.ParsingContext;
-import org.glassfish.hk2.classmodel.reflect.Type;
 import org.glassfish.hk2.classmodel.reflect.Types;
 import org.glassfish.hk2.classmodel.reflect.util.ParsingConfig;
 import org.junit.Assert;

--- a/class-model/src/test/java/org/glassfish/hk2/classmodel/reflect/test/ModelTest.java
+++ b/class-model/src/test/java/org/glassfish/hk2/classmodel/reflect/test/ModelTest.java
@@ -13,17 +13,19 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-
 package org.glassfish.hk2.classmodel.reflect.test;
 
 import org.glassfish.hk2.classmodel.reflect.*;
 
 import org.glassfish.hk2.classmodel.reflect.test.ordering.MethodDeclarationOrderTest;
 import org.glassfish.hk2.classmodel.reflect.test.parameterized.PathRouteBuilder;
+import org.glassfish.hk2.classmodel.reflect.test.parameterized.RouteBuilder;
 import org.junit.Test;
 import org.junit.Assert;
 import java.io.IOException;
-
+import org.glassfish.hk2.classmodel.reflect.test.parameterized.GenericRouteBuilder;
+import org.glassfish.hk2.classmodel.reflect.test.parameterized.PathPattern;
+import org.glassfish.hk2.classmodel.reflect.test.parameterized.Pattern;
 
 /**
  * Model related tests
@@ -36,21 +38,120 @@ public class ModelTest {
         Types types = ClassModelTestsUtils.getTypes();
         Type order = types.getBy(MethodDeclarationOrderTest.class.getName());
         Assert.assertNotNull(order);
-        Assert.assertTrue(order.getMethods().size()==4);
-        int i=1;
+        Assert.assertTrue(order.getMethods().size() == 4);
+        int i = 1;
         for (MethodModel mm : order.getMethods()) {
-            if (mm.getName().equals("<init>"))
+            if (mm.getName().equals("<init>")) {
                 continue;
+            }
 
-            Assert.assertEquals("method"+i, mm.getName());
+            Assert.assertEquals("method" + i, mm.getName());
             i++;
         }
     }
 
     @Test
-    public void parameterizedInterfacesTest() throws IOException, InterruptedException {
+    public void parameterizedInterfaceTest() throws IOException, InterruptedException {
+        Types types = ClassModelTestsUtils.getTypes();
+        ExtensibleType<?> routeBuilder = (ExtensibleType<?>) types.getBy(RouteBuilder.class.getName());
+        Assert.assertEquals(2, routeBuilder.getMethods().size());
+
+        MethodModel passMethod = routeBuilder.getMethods().stream()
+                .filter(m -> "passPattern".equals(m.getName()))
+                .findFirst()
+                .get();
+
+        Assert.assertEquals("void", passMethod.getReturnType().getTypeName());
+        Assert.assertNull(passMethod.getReturnType().getType());  //Even though it's a constant, the actual type is null
+        Assert.assertEquals(1, passMethod.getParameters().size());
+        Assert.assertEquals(Pattern.class.getName(), passMethod.getParameters().get(0).getTypeName()); //We know the constraint
+        Assert.assertNull(passMethod.getParameters().get(0).getType());  //Even though it's constrained, the actual type is null
+
+        MethodModel patternMethod = routeBuilder.getMethods().stream()
+                .filter(m -> "pattern".equals(m.getName()))
+                .findFirst()
+                .get();
+
+        Assert.assertEquals(Pattern.class.getName(), patternMethod.getReturnType().getTypeName()); //We know the constraint
+        Assert.assertNull(patternMethod.getReturnType().getType());  //Even though it's constrained, the actual type is null
+        Assert.assertEquals(0, patternMethod.getParameters().size());
+    }
+
+    @Test
+    public void parameterizedGenericInterfaceTest() throws IOException, InterruptedException {
+        Types types = ClassModelTestsUtils.getTypes();
+        ExtensibleType<?> genericRouteBuilder = (ExtensibleType<?>) types.getBy(GenericRouteBuilder.class.getName());
+        Assert.assertEquals(3, genericRouteBuilder.getMethods().size());
+
+        MethodModel passMethod = genericRouteBuilder.getMethods().stream()
+                .filter(m -> "passPattern".equals(m.getName()))
+                .findFirst()
+                .get();
+
+        Assert.assertEquals("void", passMethod.getReturnType().getTypeName());
+        Assert.assertNull(passMethod.getReturnType().getType());  //Even though it's a constant, the actual type is null
+        Assert.assertEquals(1, passMethod.getParameters().size());
+        Assert.assertEquals(Pattern.class.getName(), passMethod.getParameters().get(0).getTypeName()); //We know the constraint
+        Assert.assertNull(passMethod.getParameters().get(0).getType());  //Even though it's constrained, the actual type is null
+
+        MethodModel patternMethod = genericRouteBuilder.getMethods().stream()
+                .filter(m -> "pattern".equals(m.getName()))
+                .findFirst()
+                .get();
+
+        Assert.assertEquals(Pattern.class.getName(), patternMethod.getReturnType().getTypeName()); //We know the constraint
+        Assert.assertNull(patternMethod.getReturnType().getType());  //Even though it's constrained, the actual type is null
+        Assert.assertEquals(0, patternMethod.getParameters().size());
+
+        FieldModel pathField = ((ClassModel) genericRouteBuilder).getFields().stream()
+                .filter(f -> "path".equals(f.getName()))
+                .findFirst()
+                .get();
+
+        Assert.assertNotNull(pathField);
+        Assert.assertEquals(Pattern.class.getName(), pathField.getTypeName());
+        Assert.assertEquals(Pattern.class.getName(), pathField.getDeclaringTypeName());
+        Assert.assertNotNull(pathField.getType());
+
+    }
+
+    @Test
+    public void parameterizedInterfaceImplementerTest() throws IOException, InterruptedException {
         Types types = ClassModelTestsUtils.getTypes();
         ExtensibleType<?> pathRouteBuilder = (ExtensibleType<?>) types.getBy(PathRouteBuilder.class.getName());
-        Assert.assertEquals(pathRouteBuilder.getParameterizedInterfaces().size(), 1);
+        Assert.assertEquals(1, pathRouteBuilder.getParameterizedInterfaces().size());
+
+        Assert.assertEquals(5, pathRouteBuilder.getMethods().size());
+
+        MethodModel passMethod = pathRouteBuilder.getMethods().stream()
+                .filter(m -> "passPattern".equals(m.getName()))
+                .findFirst()
+                .get();
+
+        Assert.assertEquals("void", passMethod.getReturnType().getTypeName());
+        Assert.assertNull(passMethod.getReturnType().getType());  //Even though it's a constant, the actual type is null
+        Assert.assertEquals(1, passMethod.getParameters().size());
+        Assert.assertEquals(PathPattern.class.getName(), passMethod.getParameters().get(0).getTypeName()); //We know the value that the generic takes
+        Assert.assertNotNull(passMethod.getParameters().get(0).getType());  //Type is filled in so it exists now
+
+        MethodModel patternMethod = pathRouteBuilder.getMethods().stream()
+                .filter(m -> "pattern".equals(m.getName()))
+                .findFirst()
+                .get();
+
+        Assert.assertEquals(PathPattern.class.getName(), patternMethod.getReturnType().getTypeName());//We know the value that the generic takes
+        Assert.assertNotNull(patternMethod.getReturnType().getType()); //Type is filled in so it exists now
+        Assert.assertEquals(0, patternMethod.getParameters().size());
+
+        FieldModel pathField = ((ClassModel) pathRouteBuilder).getFields().stream()
+                .filter(f -> "path".equals(f.getName()))
+                .findFirst()
+                .get();
+
+        Assert.assertNotNull(pathField);
+        Assert.assertEquals(PathPattern.class.getName(), pathField.getTypeName());
+        Assert.assertEquals(PathPattern.class.getName(), pathField.getDeclaringTypeName());
+        Assert.assertNotNull(pathField.getType());
+
     }
 }

--- a/class-model/src/test/java/org/glassfish/hk2/classmodel/reflect/test/parameterized/GenericRouteBuilder.java
+++ b/class-model/src/test/java/org/glassfish/hk2/classmodel/reflect/test/parameterized/GenericRouteBuilder.java
@@ -30,4 +30,8 @@ public class GenericRouteBuilder<T extends Pattern> implements RouteBuilder<T> {
     public T pattern() {
         return path;
     }
+
+    @Override
+    public void passPattern(T pattern) {
+    }
 }

--- a/class-model/src/test/java/org/glassfish/hk2/classmodel/reflect/test/parameterized/PathRouteBuilder.java
+++ b/class-model/src/test/java/org/glassfish/hk2/classmodel/reflect/test/parameterized/PathRouteBuilder.java
@@ -29,4 +29,8 @@ public class PathRouteBuilder implements RouteBuilder<PathPattern> {
     public PathPattern pattern() {
         return path;
     }
+
+    @Override
+    public void passPattern(PathPattern pattern) {
+    }
 }

--- a/class-model/src/test/java/org/glassfish/hk2/classmodel/reflect/test/parameterized/RouteBuilder.java
+++ b/class-model/src/test/java/org/glassfish/hk2/classmodel/reflect/test/parameterized/RouteBuilder.java
@@ -20,6 +20,8 @@ package org.glassfish.hk2.classmodel.reflect.test.parameterized;
  * Parameterized interface
  */
 public interface RouteBuilder<T extends Pattern> {
-
+    
+    void passPattern(T pattern);
     T pattern();
+    
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/eclipse-ee4j/glassfish-hk2/pull/544