### PR TITLE
FISH-6432 Applications Take Longer To Deploy on JDK 17 (Payara 5.x)

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -27,7 +27,7 @@
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-bom</artifactId>
-    <version>2.6.1.payara-p9-SNAPSHOT</version>
+    <version>2.6.1.payara-p9</version>
     <packaging>pom</packaging>
 
     <name>HK2 Bom Pom</name>

--- a/class-model/pom.xml
+++ b/class-model/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypeImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypeImpl.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -47,14 +48,6 @@ public class TypeImpl extends AnnotatedElementImpl implements Type {
 
     synchronized void addDefiningURI(URI uri) {
         definingURIs.add(uri);
-        try {
-            File file = new File(uri);
-//            assert(file.exists()) : file + " does not exist";
-            definingURIs.add(file.getCanonicalFile().toURI());
-        } catch (IOException e) {
-            // ignore, this is a safeguard for confused user's code that do not
-            // deal well with file path.
-        }
     }
 
     @Override

--- a/examples/caching/pom.xml
+++ b/examples/caching/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/examples/caching/runner/pom.xml
+++ b/examples/caching/runner/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>caching-aop-example</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <artifactId>caching-aop-example-runner</artifactId>

--- a/examples/caching/system/pom.xml
+++ b/examples/caching/system/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>caching-aop-example</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <artifactId>caching-aop-example-system</artifactId>

--- a/examples/configuration/pom.xml
+++ b/examples/configuration/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/examples/configuration/webserver/pom.xml
+++ b/examples/configuration/webserver/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>configuration-examples</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <artifactId>webserver-configuration-example</artifactId>

--- a/examples/configuration/xml/pom.xml
+++ b/examples/configuration/xml/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>configuration-examples</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <artifactId>xml-configuration-example</artifactId>

--- a/examples/custom-resolver/pom.xml
+++ b/examples/custom-resolver/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <artifactId>custom-resolver-example</artifactId>
     <name>Custom Resolver Example</name>

--- a/examples/events/pom.xml
+++ b/examples/events/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/examples/events/threaded/pom.xml
+++ b/examples/events/threaded/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>event-examples</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <artifactId>threading-event-example</artifactId>

--- a/examples/operations/pom.xml
+++ b/examples/operations/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <artifactId>operations-example</artifactId>
     <name>Operations Example</name>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/examples/security-lockdown/alice/pom.xml
+++ b/examples/security-lockdown/alice/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>security-lockdown-example</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <artifactId>security-lockdown-example-alice</artifactId>

--- a/examples/security-lockdown/mallory/pom.xml
+++ b/examples/security-lockdown/mallory/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>security-lockdown-example</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <artifactId>security-lockdown-example-mallory</artifactId>

--- a/examples/security-lockdown/pom.xml
+++ b/examples/security-lockdown/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/examples/security-lockdown/runner/pom.xml
+++ b/examples/security-lockdown/runner/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>security-lockdown-example</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <artifactId>security-lockdown-example-runner</artifactId>

--- a/examples/security-lockdown/system/pom.xml
+++ b/examples/security-lockdown/system/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>security-lockdown-example</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <artifactId>security-lockdown-example-system</artifactId>

--- a/external/aopalliance/pom.xml
+++ b/external/aopalliance/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>external</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <groupId>org.glassfish.hk2.external</groupId>
     <artifactId>aopalliance-repackaged</artifactId>

--- a/external/jsr330/pom.xml
+++ b/external/jsr330/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>external</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <groupId>org.glassfish.hk2.external</groupId>
     <artifactId>jakarta.inject</artifactId>

--- a/external/pom.xml
+++ b/external/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/guice-bridge/pom.xml
+++ b/guice-bridge/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>guice-bridge</artifactId>

--- a/hk2-api/pom.xml
+++ b/hk2-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-api</artifactId>

--- a/hk2-configuration/hk2-integration/pom.xml
+++ b/hk2-configuration/hk2-integration/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-configuration</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <artifactId>hk2-configuration-integration</artifactId>

--- a/hk2-configuration/manager/pom.xml
+++ b/hk2-configuration/manager/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-configuration</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <artifactId>hk2-configuration-hub</artifactId>

--- a/hk2-configuration/persistence/hk2-xml/hk2-json/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/hk2-json/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <artifactId>hk2-json</artifactId>
     

--- a/hk2-configuration/persistence/hk2-xml/hk2-pbuf/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/hk2-pbuf/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <artifactId>hk2-pbuf</artifactId>
     

--- a/hk2-configuration/persistence/hk2-xml/integration-test/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/integration-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <artifactId>hk2-xml-integration-test</artifactId>
     

--- a/hk2-configuration/persistence/hk2-xml/main/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/main/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <artifactId>hk2-xml</artifactId>
     

--- a/hk2-configuration/persistence/hk2-xml/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-configuration-persistence</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/hk2-configuration/persistence/hk2-xml/schema/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/schema/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <artifactId>hk2-xml-schema</artifactId>
     

--- a/hk2-configuration/persistence/hk2-xml/test1/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/test1/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <artifactId>hk2-xml-test</artifactId>
     

--- a/hk2-configuration/persistence/pom.xml
+++ b/hk2-configuration/persistence/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-configuration</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/hk2-configuration/persistence/property-file/pom.xml
+++ b/hk2-configuration/persistence/property-file/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-configuration-persistence</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <artifactId>hk2-property-file</artifactId>
     

--- a/hk2-configuration/pom.xml
+++ b/hk2-configuration/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/hk2-core/pom.xml
+++ b/hk2-core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <artifactId>hk2-core</artifactId>
     <name>HK2 core module</name>

--- a/hk2-extras/pom.xml
+++ b/hk2-extras/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-extras</artifactId>

--- a/hk2-jmx/pom.xml
+++ b/hk2-jmx/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-jmx</artifactId>

--- a/hk2-locator/pom.xml
+++ b/hk2-locator/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <artifactId>hk2-locator</artifactId>
     <name>ServiceLocator Default Implementation</name>

--- a/hk2-metadata-generator/main/pom.xml
+++ b/hk2-metadata-generator/main/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-metadata-generator-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/hk2-metadata-generator/pom.xml
+++ b/hk2-metadata-generator/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/hk2-metadata-generator/test1/pom.xml
+++ b/hk2-metadata-generator/test1/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-metadata-generator-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-metadata-generator-test1</artifactId>

--- a/hk2-runlevel/pom.xml
+++ b/hk2-runlevel/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <artifactId>hk2-runlevel</artifactId>

--- a/hk2-testing/ant/pom.xml
+++ b/hk2-testing/ant/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     

--- a/hk2-testing/collections/pom.xml
+++ b/hk2-testing/collections/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-testing</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <artifactId>hk2-collections-tests</artifactId>

--- a/hk2-testing/hk2-junitrunner/pom.xml
+++ b/hk2-testing/hk2-junitrunner/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>hk2-junitrunner</artifactId>

--- a/hk2-testing/hk2-locator-extras/pom.xml
+++ b/hk2-testing/hk2-locator-extras/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>hk2-locator-extras</artifactId>

--- a/hk2-testing/hk2-locator-no-proxies/pom.xml
+++ b/hk2-testing/hk2-locator-no-proxies/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>hk2-locator-no-proxies</artifactId>

--- a/hk2-testing/hk2-locator-no-proxies2/pom.xml
+++ b/hk2-testing/hk2-locator-no-proxies2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/hk2-mockito/pom.xml
+++ b/hk2-testing/hk2-mockito/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-testing</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <artifactId>hk2-mockito</artifactId>
     <name>HK2 Mockito</name>

--- a/hk2-testing/hk2-runlevel-extras/pom.xml
+++ b/hk2-testing/hk2-runlevel-extras/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>hk2-runlevel-extras</artifactId>

--- a/hk2-testing/hk2-testng/pom.xml
+++ b/hk2-testing/hk2-testng/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>hk2-testng</artifactId>

--- a/hk2-testing/interceptor-events/pom.xml
+++ b/hk2-testing/interceptor-events/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-testing</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <artifactId>interceptor-events</artifactId>

--- a/hk2-testing/jersey/jersey-guice/form-param/pom.xml
+++ b/hk2-testing/jersey/jersey-guice/form-param/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/jersey/jersey-guice/pom.xml
+++ b/hk2-testing/jersey/jersey-guice/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/jersey/pom.xml
+++ b/hk2-testing/jersey/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/pom.xml
+++ b/hk2-testing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/hk2-utils/pom.xml
+++ b/hk2-utils/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-utils</artifactId>

--- a/hk2/pom.xml
+++ b/hk2/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>hk2</artifactId>

--- a/maven-plugins/consolidatedbundle-maven-plugin/pom.xml
+++ b/maven-plugins/consolidatedbundle-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>maven-plugins</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <artifactId>consolidatedbundle-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>

--- a/maven-plugins/hk2-inhabitant-generator/pom.xml
+++ b/maven-plugins/hk2-inhabitant-generator/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>maven-plugins</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <artifactId>hk2-inhabitant-generator</artifactId>
     <packaging>maven-plugin</packaging>

--- a/maven-plugins/osgiversion-maven-plugin/pom.xml
+++ b/maven-plugins/osgiversion-maven-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>maven-plugins</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <artifactId>osgiversion-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>

--- a/maven-plugins/pom.xml
+++ b/maven-plugins/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <artifactId>maven-plugins</artifactId>
     <packaging>pom</packaging>

--- a/osgi/adapter-tests/contract-bundle/pom.xml
+++ b/osgi/adapter-tests/contract-bundle/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <artifactId>contract-bundle</artifactId>

--- a/osgi/adapter-tests/faux-sdp-bundle/pom.xml
+++ b/osgi/adapter-tests/faux-sdp-bundle/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <artifactId>faux-sdp-bundle</artifactId>

--- a/osgi/adapter-tests/no-hk2-bundle/pom.xml
+++ b/osgi/adapter-tests/no-hk2-bundle/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <artifactId>no-hk2-bundle</artifactId>

--- a/osgi/adapter-tests/osgi-adapter-test/pom.xml
+++ b/osgi/adapter-tests/osgi-adapter-test/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>osgi-adapter-test</artifactId>

--- a/osgi/adapter-tests/pom.xml
+++ b/osgi/adapter-tests/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/osgi/adapter-tests/sdp-management-bundle/pom.xml
+++ b/osgi/adapter-tests/sdp-management-bundle/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <artifactId>sdp-management-bundle</artifactId>

--- a/osgi/adapter-tests/test-module-startup/pom.xml
+++ b/osgi/adapter-tests/test-module-startup/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
 
     <artifactId>test-module-startup</artifactId>

--- a/osgi/adapter/pom.xml
+++ b/osgi/adapter/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <artifactId>osgi-adapter</artifactId>
     <name>HK2 OSGi Adapter</name>

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>osgi</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-parent</artifactId>
-    <version>2.6.1.payara-p9-SNAPSHOT</version>
+    <version>2.6.1.payara-p9</version>
     <packaging>pom</packaging>
 
     <name>GlassFish HK2</name>

--- a/spring-bridge/pom.xml
+++ b/spring-bridge/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>2.6.1.payara-p9-SNAPSHOT</version>
+        <version>2.6.1.payara-p9</version>
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>spring-bridge</artifactId>


### PR DESCRIPTION
File canonicalization cache is disabled by default in JDK 12 which helps in performance optimizations for file name canonicalization. In TypeImpl#addDefiningURI duplicate uri is added so canonicalization is not required.