### PR TITLE
FISH-8635 Add Missing OSGi Exports to HK2-Extras

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-bom</artifactId>
-    <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+    <version>4.0.0-M2.payara-p2</version>
     <packaging>pom</packaging>
 
     <name>HK2 Bom Pom</name>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-bom</artifactId>
-    <version>4.0.0-M2.payara-p2</version>
+    <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>HK2 Bom Pom</name>

--- a/class-model/pom.xml
+++ b/class-model/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/class-model/pom.xml
+++ b/class-model/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/examples/caching/pom.xml
+++ b/examples/caching/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>caching-aop-example</artifactId>

--- a/examples/caching/pom.xml
+++ b/examples/caching/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>caching-aop-example</artifactId>

--- a/examples/caching/runner/pom.xml
+++ b/examples/caching/runner/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>caching-aop-example</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>caching-aop-example-runner</artifactId>

--- a/examples/caching/runner/pom.xml
+++ b/examples/caching/runner/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>caching-aop-example</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>caching-aop-example-runner</artifactId>

--- a/examples/caching/system/pom.xml
+++ b/examples/caching/system/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>caching-aop-example</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>caching-aop-example-system</artifactId>

--- a/examples/caching/system/pom.xml
+++ b/examples/caching/system/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>caching-aop-example</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>caching-aop-example-system</artifactId>

--- a/examples/configuration/pom.xml
+++ b/examples/configuration/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>configuration-examples</artifactId>

--- a/examples/configuration/pom.xml
+++ b/examples/configuration/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>configuration-examples</artifactId>

--- a/examples/configuration/webserver/pom.xml
+++ b/examples/configuration/webserver/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>configuration-examples</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>webserver-configuration-example</artifactId>

--- a/examples/configuration/webserver/pom.xml
+++ b/examples/configuration/webserver/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>configuration-examples</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>webserver-configuration-example</artifactId>

--- a/examples/configuration/xml/pom.xml
+++ b/examples/configuration/xml/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>configuration-examples</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>xml-configuration-example</artifactId>

--- a/examples/configuration/xml/pom.xml
+++ b/examples/configuration/xml/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>configuration-examples</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>xml-configuration-example</artifactId>

--- a/examples/custom-resolver/pom.xml
+++ b/examples/custom-resolver/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>custom-resolver-example</artifactId>

--- a/examples/custom-resolver/pom.xml
+++ b/examples/custom-resolver/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>custom-resolver-example</artifactId>

--- a/examples/events/pom.xml
+++ b/examples/events/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>event-examples</artifactId>

--- a/examples/events/pom.xml
+++ b/examples/events/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>event-examples</artifactId>

--- a/examples/events/threaded/pom.xml
+++ b/examples/events/threaded/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>event-examples</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>threading-event-example</artifactId>

--- a/examples/events/threaded/pom.xml
+++ b/examples/events/threaded/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>event-examples</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>threading-event-example</artifactId>

--- a/examples/operations/pom.xml
+++ b/examples/operations/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>operations-example</artifactId>

--- a/examples/operations/pom.xml
+++ b/examples/operations/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>operations-example</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>examples</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>examples</artifactId>

--- a/examples/security-lockdown/alice/pom.xml
+++ b/examples/security-lockdown/alice/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>security-lockdown-example</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>security-lockdown-example-alice</artifactId>

--- a/examples/security-lockdown/alice/pom.xml
+++ b/examples/security-lockdown/alice/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>security-lockdown-example</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>security-lockdown-example-alice</artifactId>

--- a/examples/security-lockdown/mallory/pom.xml
+++ b/examples/security-lockdown/mallory/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>security-lockdown-example</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>security-lockdown-example-mallory</artifactId>

--- a/examples/security-lockdown/mallory/pom.xml
+++ b/examples/security-lockdown/mallory/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>security-lockdown-example</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>security-lockdown-example-mallory</artifactId>

--- a/examples/security-lockdown/pom.xml
+++ b/examples/security-lockdown/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>security-lockdown-example</artifactId>

--- a/examples/security-lockdown/pom.xml
+++ b/examples/security-lockdown/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>examples</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>security-lockdown-example</artifactId>

--- a/examples/security-lockdown/runner/pom.xml
+++ b/examples/security-lockdown/runner/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>security-lockdown-example</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>security-lockdown-example-runner</artifactId>

--- a/examples/security-lockdown/runner/pom.xml
+++ b/examples/security-lockdown/runner/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>security-lockdown-example</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>security-lockdown-example-runner</artifactId>

--- a/examples/security-lockdown/system/pom.xml
+++ b/examples/security-lockdown/system/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>security-lockdown-example</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>security-lockdown-example-system</artifactId>

--- a/examples/security-lockdown/system/pom.xml
+++ b/examples/security-lockdown/system/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>security-lockdown-example</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>security-lockdown-example-system</artifactId>

--- a/external/aopalliance/pom.xml
+++ b/external/aopalliance/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>external</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.hk2.external</groupId>

--- a/external/aopalliance/pom.xml
+++ b/external/aopalliance/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>external</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.hk2.external</groupId>

--- a/external/pom.xml
+++ b/external/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>external</artifactId>

--- a/external/pom.xml
+++ b/external/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>external</artifactId>

--- a/guice-bridge/pom.xml
+++ b/guice-bridge/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/guice-bridge/pom.xml
+++ b/guice-bridge/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/hk2-api/pom.xml
+++ b/hk2-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/hk2-api/pom.xml
+++ b/hk2-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/hk2-configuration/hk2-integration/pom.xml
+++ b/hk2-configuration/hk2-integration/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-configuration</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>hk2-configuration-integration</artifactId>

--- a/hk2-configuration/hk2-integration/pom.xml
+++ b/hk2-configuration/hk2-integration/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-configuration</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hk2-configuration-integration</artifactId>

--- a/hk2-configuration/manager/pom.xml
+++ b/hk2-configuration/manager/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-configuration</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hk2-configuration-hub</artifactId>

--- a/hk2-configuration/manager/pom.xml
+++ b/hk2-configuration/manager/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-configuration</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>hk2-configuration-hub</artifactId>

--- a/hk2-configuration/persistence/hk2-xml/hk2-json/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/hk2-json/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hk2-json</artifactId>

--- a/hk2-configuration/persistence/hk2-xml/hk2-json/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/hk2-json/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>hk2-json</artifactId>

--- a/hk2-configuration/persistence/hk2-xml/hk2-pbuf/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/hk2-pbuf/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>hk2-pbuf</artifactId>

--- a/hk2-configuration/persistence/hk2-xml/hk2-pbuf/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/hk2-pbuf/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hk2-pbuf</artifactId>

--- a/hk2-configuration/persistence/hk2-xml/integration-test/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/integration-test/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>hk2-xml-integration-test</artifactId>

--- a/hk2-configuration/persistence/hk2-xml/integration-test/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/integration-test/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hk2-xml-integration-test</artifactId>

--- a/hk2-configuration/persistence/hk2-xml/main/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/main/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>hk2-xml</artifactId>

--- a/hk2-configuration/persistence/hk2-xml/main/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/main/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hk2-xml</artifactId>

--- a/hk2-configuration/persistence/hk2-xml/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-configuration-persistence</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>hk2-xml-parent</artifactId>

--- a/hk2-configuration/persistence/hk2-xml/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-configuration-persistence</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hk2-xml-parent</artifactId>

--- a/hk2-configuration/persistence/hk2-xml/schema/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/schema/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hk2-xml-schema</artifactId>

--- a/hk2-configuration/persistence/hk2-xml/schema/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/schema/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>hk2-xml-schema</artifactId>

--- a/hk2-configuration/persistence/hk2-xml/test1/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/test1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hk2-xml-test</artifactId>

--- a/hk2-configuration/persistence/hk2-xml/test1/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/test1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-xml-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>hk2-xml-test</artifactId>

--- a/hk2-configuration/persistence/pom.xml
+++ b/hk2-configuration/persistence/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-configuration</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>hk2-configuration-persistence</artifactId>

--- a/hk2-configuration/persistence/pom.xml
+++ b/hk2-configuration/persistence/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-configuration</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hk2-configuration-persistence</artifactId>

--- a/hk2-configuration/persistence/property-file/pom.xml
+++ b/hk2-configuration/persistence/property-file/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-configuration-persistence</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>hk2-property-file</artifactId>

--- a/hk2-configuration/persistence/property-file/pom.xml
+++ b/hk2-configuration/persistence/property-file/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-configuration-persistence</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hk2-property-file</artifactId>

--- a/hk2-configuration/pom.xml
+++ b/hk2-configuration/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>hk2-configuration</artifactId>

--- a/hk2-configuration/pom.xml
+++ b/hk2-configuration/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hk2-configuration</artifactId>

--- a/hk2-core/pom.xml
+++ b/hk2-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>hk2-core</artifactId>

--- a/hk2-core/pom.xml
+++ b/hk2-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hk2-core</artifactId>

--- a/hk2-extras/pom.xml
+++ b/hk2-extras/pom.xml
@@ -84,6 +84,17 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Export-Package>
+                            org.glassfish.hk2.extras; \
+                            org.glassfish.hk2.extras.events; \
+                            org.glassfish.hk2.extras.interception; \
+                            org.glassfish.hk2.extras.operation; \
+                            org.glassfish.hk2.extras.provides; version=${project.osgi.version}
+                        </Export-Package>
+                    </instructions>
+                </configuration>
                 <executions>
                     <execution>
                         <id>bundle-manifest</id>

--- a/hk2-extras/pom.xml
+++ b/hk2-extras/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/hk2-extras/pom.xml
+++ b/hk2-extras/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/hk2-jmx/pom.xml
+++ b/hk2-jmx/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/hk2-jmx/pom.xml
+++ b/hk2-jmx/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/hk2-locator/pom.xml
+++ b/hk2-locator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hk2-locator</artifactId>

--- a/hk2-locator/pom.xml
+++ b/hk2-locator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>hk2-locator</artifactId>

--- a/hk2-metadata-generator/main/pom.xml
+++ b/hk2-metadata-generator/main/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-metadata-generator-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/hk2-metadata-generator/main/pom.xml
+++ b/hk2-metadata-generator/main/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-metadata-generator-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/hk2-metadata-generator/pom.xml
+++ b/hk2-metadata-generator/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hk2-metadata-generator-parent</artifactId>

--- a/hk2-metadata-generator/pom.xml
+++ b/hk2-metadata-generator/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>hk2-metadata-generator-parent</artifactId>

--- a/hk2-metadata-generator/test1/pom.xml
+++ b/hk2-metadata-generator/test1/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-metadata-generator-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/hk2-metadata-generator/test1/pom.xml
+++ b/hk2-metadata-generator/test1/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-metadata-generator-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/hk2-runlevel/pom.xml
+++ b/hk2-runlevel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>hk2-runlevel</artifactId>

--- a/hk2-runlevel/pom.xml
+++ b/hk2-runlevel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hk2-runlevel</artifactId>

--- a/hk2-testing/ant/pom.xml
+++ b/hk2-testing/ant/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/ant/pom.xml
+++ b/hk2-testing/ant/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/collections/pom.xml
+++ b/hk2-testing/collections/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-testing</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>hk2-collections-tests</artifactId>

--- a/hk2-testing/collections/pom.xml
+++ b/hk2-testing/collections/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-testing</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hk2-collections-tests</artifactId>

--- a/hk2-testing/di-tck/pom.xml
+++ b/hk2-testing/di-tck/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-testing</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>hk2-di-tck-runner</artifactId>

--- a/hk2-testing/di-tck/pom.xml
+++ b/hk2-testing/di-tck/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-testing</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hk2-di-tck-runner</artifactId>

--- a/hk2-testing/hk2-junitrunner/pom.xml
+++ b/hk2-testing/hk2-junitrunner/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/hk2-junitrunner/pom.xml
+++ b/hk2-testing/hk2-junitrunner/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/hk2-locator-extras/pom.xml
+++ b/hk2-testing/hk2-locator-extras/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/hk2-locator-extras/pom.xml
+++ b/hk2-testing/hk2-locator-extras/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/hk2-locator-no-proxies/pom.xml
+++ b/hk2-testing/hk2-locator-no-proxies/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/hk2-locator-no-proxies/pom.xml
+++ b/hk2-testing/hk2-locator-no-proxies/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/hk2-locator-no-proxies2/pom.xml
+++ b/hk2-testing/hk2-locator-no-proxies2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/hk2-locator-no-proxies2/pom.xml
+++ b/hk2-testing/hk2-locator-no-proxies2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/hk2-mockito/pom.xml
+++ b/hk2-testing/hk2-mockito/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-testing</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hk2-mockito</artifactId>

--- a/hk2-testing/hk2-mockito/pom.xml
+++ b/hk2-testing/hk2-mockito/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-testing</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>hk2-mockito</artifactId>

--- a/hk2-testing/hk2-runlevel-extras/pom.xml
+++ b/hk2-testing/hk2-runlevel-extras/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/hk2-runlevel-extras/pom.xml
+++ b/hk2-testing/hk2-runlevel-extras/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/hk2-testng/pom.xml
+++ b/hk2-testing/hk2-testng/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/hk2-testng/pom.xml
+++ b/hk2-testing/hk2-testng/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/interceptor-events/pom.xml
+++ b/hk2-testing/interceptor-events/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-testing</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>interceptor-events</artifactId>

--- a/hk2-testing/interceptor-events/pom.xml
+++ b/hk2-testing/interceptor-events/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-testing</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>interceptor-events</artifactId>

--- a/hk2-testing/jersey/jersey-guice/form-param/pom.xml
+++ b/hk2-testing/jersey/jersey-guice/form-param/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/jersey/jersey-guice/form-param/pom.xml
+++ b/hk2-testing/jersey/jersey-guice/form-param/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/jersey/jersey-guice/pom.xml
+++ b/hk2-testing/jersey/jersey-guice/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/jersey/jersey-guice/pom.xml
+++ b/hk2-testing/jersey/jersey-guice/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/jersey/pom.xml
+++ b/hk2-testing/jersey/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/jersey/pom.xml
+++ b/hk2-testing/jersey/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/hk2-testing/pom.xml
+++ b/hk2-testing/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hk2-testing</artifactId>

--- a/hk2-testing/pom.xml
+++ b/hk2-testing/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>hk2-testing</artifactId>

--- a/hk2-utils/pom.xml
+++ b/hk2-utils/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/hk2-utils/pom.xml
+++ b/hk2-utils/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/hk2/pom.xml
+++ b/hk2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hk2</artifactId>

--- a/hk2/pom.xml
+++ b/hk2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>hk2</artifactId>

--- a/javadocs/pom.xml
+++ b/javadocs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
     <artifactId>hk2-javadocs</artifactId>
     <name>HK2 Javadocs</name>

--- a/javadocs/pom.xml
+++ b/javadocs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
     <artifactId>hk2-javadocs</artifactId>
     <name>HK2 Javadocs</name>

--- a/maven-plugins/consolidatedbundle-maven-plugin/pom.xml
+++ b/maven-plugins/consolidatedbundle-maven-plugin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>maven-plugins</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>consolidatedbundle-maven-plugin</artifactId>

--- a/maven-plugins/consolidatedbundle-maven-plugin/pom.xml
+++ b/maven-plugins/consolidatedbundle-maven-plugin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>maven-plugins</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>consolidatedbundle-maven-plugin</artifactId>

--- a/maven-plugins/hk2-inhabitant-generator/pom.xml
+++ b/maven-plugins/hk2-inhabitant-generator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>maven-plugins</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hk2-inhabitant-generator</artifactId>

--- a/maven-plugins/hk2-inhabitant-generator/pom.xml
+++ b/maven-plugins/hk2-inhabitant-generator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>maven-plugins</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>hk2-inhabitant-generator</artifactId>

--- a/maven-plugins/osgiversion-maven-plugin/pom.xml
+++ b/maven-plugins/osgiversion-maven-plugin/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>maven-plugins</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>osgiversion-maven-plugin</artifactId>

--- a/maven-plugins/osgiversion-maven-plugin/pom.xml
+++ b/maven-plugins/osgiversion-maven-plugin/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>maven-plugins</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>osgiversion-maven-plugin</artifactId>

--- a/maven-plugins/pom.xml
+++ b/maven-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>maven-plugins</artifactId>

--- a/maven-plugins/pom.xml
+++ b/maven-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>maven-plugins</artifactId>

--- a/osgi/adapter-tests/contract-bundle/pom.xml
+++ b/osgi/adapter-tests/contract-bundle/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>contract-bundle</artifactId>

--- a/osgi/adapter-tests/contract-bundle/pom.xml
+++ b/osgi/adapter-tests/contract-bundle/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>contract-bundle</artifactId>

--- a/osgi/adapter-tests/faux-sdp-bundle/pom.xml
+++ b/osgi/adapter-tests/faux-sdp-bundle/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>faux-sdp-bundle</artifactId>

--- a/osgi/adapter-tests/faux-sdp-bundle/pom.xml
+++ b/osgi/adapter-tests/faux-sdp-bundle/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>faux-sdp-bundle</artifactId>

--- a/osgi/adapter-tests/no-hk2-bundle/pom.xml
+++ b/osgi/adapter-tests/no-hk2-bundle/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>no-hk2-bundle</artifactId>

--- a/osgi/adapter-tests/no-hk2-bundle/pom.xml
+++ b/osgi/adapter-tests/no-hk2-bundle/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>no-hk2-bundle</artifactId>

--- a/osgi/adapter-tests/osgi-adapter-test/pom.xml
+++ b/osgi/adapter-tests/osgi-adapter-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>osgi-adapter-test</artifactId>

--- a/osgi/adapter-tests/osgi-adapter-test/pom.xml
+++ b/osgi/adapter-tests/osgi-adapter-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>osgi-adapter-test</artifactId>

--- a/osgi/adapter-tests/pom.xml
+++ b/osgi/adapter-tests/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/osgi/adapter-tests/pom.xml
+++ b/osgi/adapter-tests/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/osgi/adapter-tests/sdp-management-bundle/pom.xml
+++ b/osgi/adapter-tests/sdp-management-bundle/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>sdp-management-bundle</artifactId>

--- a/osgi/adapter-tests/sdp-management-bundle/pom.xml
+++ b/osgi/adapter-tests/sdp-management-bundle/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>sdp-management-bundle</artifactId>

--- a/osgi/adapter-tests/test-module-startup/pom.xml
+++ b/osgi/adapter-tests/test-module-startup/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>test-module-startup</artifactId>

--- a/osgi/adapter-tests/test-module-startup/pom.xml
+++ b/osgi/adapter-tests/test-module-startup/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-adapter-tests-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>test-module-startup</artifactId>

--- a/osgi/adapter/pom.xml
+++ b/osgi/adapter/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>osgi-adapter</artifactId>

--- a/osgi/adapter/pom.xml
+++ b/osgi/adapter/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>osgi-adapter</artifactId>

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>osgi</artifactId>

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <artifactId>osgi</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-parent</artifactId>
-    <version>4.0.0-M2.payara-p2</version>
+    <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>GlassFish HK2</name>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-parent</artifactId>
-    <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+    <version>4.0.0-M2.payara-p2</version>
     <packaging>pom</packaging>
 
     <name>GlassFish HK2</name>

--- a/spring-bridge/pom.xml
+++ b/spring-bridge/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0-M2.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>

--- a/spring-bridge/pom.xml
+++ b/spring-bridge/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
-        <version>4.0.0-M2.payara-p2</version>
+        <version>4.0.0-M2.payara-p3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.hk2</groupId>


### PR DESCRIPTION
Adds the missing OSGi exports to the HK2 Extras module, as they "fixed" the bundle plugin configuration upstream which meant that nothing was being exported by this module.