### PR TITLE
Fish 11911 adding latest changes for race condition lock mechanism

### DIFF
--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/Parser.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/Parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -32,6 +32,7 @@ import java.net.URL;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -48,6 +49,8 @@ public class Parser implements Closeable {
     private final ParsingContext context;
     private final Map<String, Types> processedURI = Collections.synchronizedMap(new HashMap<String, Types>());
 
+    private final ReentrantLock thislock = new ReentrantLock();
+    private final ReentrantLock futuresLock = new ReentrantLock();
     private final Stack<Future<Result>> futures = new Stack<Future<Result>>();
     private final ExecutorService executorService;
     private final boolean ownES;
@@ -76,14 +79,17 @@ public class Parser implements Closeable {
                  context.logger.log(Level.FINE, "Await iterating at " + System.currentTimeMillis() + " waiting for " + futures.size());
             }
             Future<Result> f;
-            synchronized(futures) {
-                try {
-                    f = futures.pop();
-                } catch(EmptyStackException e) {
-                    // it's ok, another thread took the load from us.
-                    f = null;
-                }
+
+            try {
+                futuresLock.lock();
+                f = futures.pop();
+            } catch (EmptyStackException e) {
+                // it's ok, another thread took the load from us.
+                f = null;
+            } finally {
+                futuresLock.unlock();
             }
+            
             if (f!=null) {
                 try {
                     Result result = f.get(timeOut, unit);
@@ -286,8 +292,11 @@ public class Parser implements Closeable {
                     }
                 }
             });
-            synchronized(futures) {
+            try {
+                futuresLock.lock();
                 futures.add(future);
+            } finally {
+                futuresLock.unlock();
             }
             if (immediateShutdown) {
                 es.shutdown();
@@ -298,12 +307,22 @@ public class Parser implements Closeable {
         }
     }
 
-    private synchronized Types getResult(URI uri) {
-        return processedURI.get(uri.getSchemeSpecificPart());
+    private Types getResult(URI uri) {
+        thislock.lock();
+        try {
+            return processedURI.get(uri.getSchemeSpecificPart());
+        } finally {
+            thislock.unlock();
+        }
     }
                                
-    private synchronized void saveResult(URI uri, Types types) {
-        this.processedURI.put(uri.getPath(), types);
+    private void saveResult(URI uri, Types types) {
+        thislock.lock();
+        try {
+            this.processedURI.put(uri.getPath(), types);
+        } finally {
+            thislock.unlock();
+        }
     }
 
     private void doJob(final ArchiveAdapter adapter, final Runnable doneHook) throws Exception {

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/ParsingContext.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/ParsingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.locks.ReentrantLock;
 import java.net.URI;
 import java.util.logging.Logger;
 
@@ -149,6 +150,7 @@ public class ParsingContext {
     final Logger logger;
     final ParsingConfig config;
     final ResourceLocator locator;
+    final ReentrantLock lock = new ReentrantLock();
 
     private ParsingContext(Builder builder) {
 //        Runtime runtime = Runtime.getRuntime();
@@ -178,13 +180,18 @@ public class ParsingContext {
 
     Map<URI, TypeBuilder> builders = new HashMap<URI, TypeBuilder>();
 
-    public synchronized TypeBuilder getTypeBuilder(URI definingURI) {
-        TypeBuilder builder = builders.get(definingURI);
-        if (builder==null) {
-            builder = new TypesImpl(types, definingURI);
-            builders.put(definingURI, builder);
+    public TypeBuilder getTypeBuilder(URI definingURI) {
+        lock.lock();
+        try {
+            TypeBuilder builder = builders.get(definingURI);
+            if (builder == null) {
+                builder = new TypesImpl(types, definingURI);
+                builders.put(definingURI, builder);
+            }
+            return builder;
+        } finally {
+            lock.unlock();
         }
-        return builder;
     }
 
     /**

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/AnnotatedElementImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/AnnotatedElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,7 @@ package org.glassfish.hk2.classmodel.reflect.impl;
 
 import org.glassfish.hk2.classmodel.reflect.*;
 
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.*;
 
 /**
@@ -26,7 +27,8 @@ import java.util.*;
  * @author Jerome Dochez
  */
 public class AnnotatedElementImpl implements AnnotatedElement {
-    
+
+    private final ReentrantLock lock = new ReentrantLock();
     private final String name;
 
     private final List<AnnotationModel> annotations = new ArrayList<AnnotationModel>();
@@ -42,8 +44,13 @@ public class AnnotatedElementImpl implements AnnotatedElement {
         return name;
     }
 
-    synchronized void addAnnotation(AnnotationModel annotation) {
-        annotations.add(annotation);
+    void addAnnotation(AnnotationModel annotation) {
+        lock.lock();
+        try {
+            annotations.add(annotation);
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ClassModelImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ClassModelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,12 +19,14 @@ package org.glassfish.hk2.classmodel.reflect.impl;
 import org.glassfish.hk2.classmodel.reflect.*;
 
 import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Implementation of a class model
  */
 public class ClassModelImpl extends ExtensibleTypeImpl<ClassModel> implements ClassModel {
 
+    private final ReentrantLock lock = new ReentrantLock();
     final List<FieldModel> fields = new ArrayList<>();
 
     public ClassModelImpl(String name, TypeProxy<Type> sink, TypeProxy parent) {
@@ -32,8 +34,13 @@ public class ClassModelImpl extends ExtensibleTypeImpl<ClassModel> implements Cl
     }
     
     @Override
-    synchronized void addField(FieldModel field) {
-        fields.add(field);
+    void addField(FieldModel field) {
+        lock.lock();
+        try {
+            fields.add(field);
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ExtensibleTypeImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ExtensibleTypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,12 +18,14 @@ package org.glassfish.hk2.classmodel.reflect.impl;
 
 import org.glassfish.hk2.classmodel.reflect.*;
 import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Implementation of an extensible type (Class or Interface)
  */
 public abstract class ExtensibleTypeImpl<T extends ExtensibleType> extends TypeImpl implements ExtensibleType<T> {
 
+    private final ReentrantLock lock = new ReentrantLock();
     protected TypeProxy<?> parent;
     private final List<FieldModel> staticFields = new ArrayList<>();
     private final List<TypeProxy<InterfaceModel>> implementedIntf = new ArrayList<>();
@@ -76,22 +78,37 @@ public abstract class ExtensibleTypeImpl<T extends ExtensibleType> extends TypeI
         return simpleName;
     }
 
-    public synchronized TypeProxy<?> setParent(final TypeProxy<?> parent) {
-        if (null == this.parent) { 
-          this.parent = parent;
+    public TypeProxy<?> setParent(final TypeProxy<?> parent) {
+        lock.lock();
+        try {
+            if (null == this.parent) {
+                this.parent = parent;
+            }
+            return this.parent;
+        } finally {
+            lock.unlock();
         }
-        return this.parent;
     }
 
-    synchronized void isImplementing(TypeProxy<InterfaceModel> intf) {
-        implementedIntf.add(intf);
+    void isImplementing(TypeProxy<InterfaceModel> intf) {
+        try {
+            lock.lock();
+            implementedIntf.add(intf);
+        } finally {
+            lock.unlock();
+        }
     }
 
-    synchronized void isImplementing(ParameterizedInterfaceModelImpl pim) {
-        if (pim.getRawInterface() instanceof InterfaceModel) {
-            implementedIntf.add((TypeProxy<InterfaceModel>) pim.getRawInterfaceProxy());
+    void isImplementing(ParameterizedInterfaceModelImpl pim) {
+        try {
+            lock.lock();
+            if (pim.getRawInterface() instanceof InterfaceModel) {
+                implementedIntf.add((TypeProxy<InterfaceModel>) pim.getRawInterfaceProxy());
+            }
+            implementedParameterizedIntf.add(pim);
+        } finally {
+            lock.unlock();
         }
-        implementedParameterizedIntf.add(pim);
     }
 
     @Override
@@ -132,8 +149,13 @@ public abstract class ExtensibleTypeImpl<T extends ExtensibleType> extends TypeI
         return allTypes;
     }
 
-    synchronized void addStaticField(FieldModel field) {
-        staticFields.add(field);
+    void addStaticField(FieldModel field) {
+        try {
+            lock.lock();
+            staticFields.add(field);
+        } finally {
+            lock.unlock();
+        }
     }
 
     void addField(FieldModel field) {

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ParameterizedInterfaceModelImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ParameterizedInterfaceModelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,7 @@ import org.glassfish.hk2.classmodel.reflect.ParameterizedInterfaceModel;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.glassfish.hk2.classmodel.reflect.ExtensibleType;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Implementation of the {@link ParameterizedInterfaceModel}
@@ -30,6 +31,7 @@ import org.glassfish.hk2.classmodel.reflect.ExtensibleType;
  */
 class ParameterizedInterfaceModelImpl implements ParameterizedInterfaceModel {
 
+    private final ReentrantLock lock = new ReentrantLock();
     final TypeProxy<ExtensibleType> rawInterface;
     final List<ParameterizedInterfaceModel> parameterizedTypes = new ArrayList<>();
 
@@ -37,8 +39,13 @@ class ParameterizedInterfaceModelImpl implements ParameterizedInterfaceModel {
         this.rawInterface = rawInterface;
     }
 
-    synchronized void addParameterizedType(ParameterizedInterfaceModel type) {
-        parameterizedTypes.add(type);
+    void addParameterizedType(ParameterizedInterfaceModel type) {
+        lock.lock();
+        try {
+            parameterizedTypes.add(type);
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypeImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -22,6 +22,7 @@ import org.glassfish.hk2.classmodel.reflect.*;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
 import java.net.URI;
 
 /**
@@ -31,6 +32,7 @@ import java.net.URI;
  */
 public class TypeImpl extends AnnotatedElementImpl implements Type {
 
+    private final ReentrantLock lock = new ReentrantLock();
     private final TypeProxy<Type> sink;
     private final List<MethodModel> methods = new ArrayList<MethodModel>();
     private final Set<URI> definingURIs= new HashSet<URI>();
@@ -46,8 +48,13 @@ public class TypeImpl extends AnnotatedElementImpl implements Type {
         return Collections.unmodifiableSet(definingURIs);
     }
 
-    synchronized void addDefiningURI(URI uri) {
-        definingURIs.add(uri);
+    void addDefiningURI(URI uri) {
+        lock.lock();
+        try {
+            definingURIs.add(uri);
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override
@@ -60,8 +67,13 @@ public class TypeImpl extends AnnotatedElementImpl implements Type {
         return false;
     }
 
-    synchronized void addMethod(MethodModelImpl m) {
-        methods.add(m);
+    void addMethod(MethodModelImpl m) {
+        lock.lock();
+        try {
+            methods.add(m);
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypeProxy.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypeProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,6 +19,7 @@ package org.glassfish.hk2.classmodel.reflect.impl;
 import org.glassfish.hk2.classmodel.reflect.*;
 
 import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Proxy for types, used in place until the type can be properly instantiated.
@@ -35,7 +36,7 @@ public class TypeProxy<T extends Type> {
     private final List<Member> fieldRefs = new ArrayList<Member>();
     private final List<Type> subTypeRefs = new ArrayList<Type>();
     private final List<ClassModel> implementations = new ArrayList<ClassModel>();
-
+    final ReentrantLock lock = new ReentrantLock();
 
     /**
      * Creates a new type proxy, this ctor is package private as many
@@ -76,24 +77,39 @@ public class TypeProxy<T extends Type> {
         public void valueSet(T value);
     }
 
-    public synchronized void addFieldRef(FieldModel field) {
-        fieldRefs.add(field);
+    public void addFieldRef(FieldModel field) {
+        lock.lock();
+        try {
+            fieldRefs.add(field);
+        } finally {
+            lock.unlock();
+        }
     }
 
     public List<Member> getRefs() {
         return Collections.unmodifiableList(fieldRefs);
     }
 
-    public synchronized void addSubTypeRef(Type subType) {
-        subTypeRefs.add(subType);
+    public void addSubTypeRef(Type subType) {
+        lock.lock();
+        try {
+            subTypeRefs.add(subType);
+        } finally {
+            lock.unlock();
+        }
     }
 
     public List<Type> getSubTypeRefs() {
         return Collections.unmodifiableList(subTypeRefs);
     }
 
-    public synchronized void addImplementation(ClassModel classModel) {
-        implementations.add(classModel);
+    public void addImplementation(ClassModel classModel) {
+        lock.lock();
+        try {
+            implementations.add(classModel);
+        } finally {
+            lock.unlock();
+        }
     }
 
     public List<ClassModel> getImplementations() {

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypesCtr.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypesCtr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,7 @@ import org.glassfish.hk2.classmodel.reflect.Types;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * contains all the parsed types references.
@@ -93,11 +94,14 @@ public class TypesCtr implements Types {
             TypeProxy<Type> tmp = unknownTypesStorage.get(name);
             // in our unknown type pool ?
             if (tmp!=null) {
-                synchronized (unknownTypesStorage) {
+                unknownTypesStorageLock.lock();
+                try {
                     typeProxy = unknownTypesStorage.remove(name);
                     if (typeProxy == null) { 
                         typeProxy = tmp; 
                      }
+                } finally {
+                    unknownTypesStorageLock.unlock();
                 }
                 if (typeProxy!=null) {
                     TypeProxy<Type> old = typeStorage.putIfAbsent(name, typeProxy);
@@ -159,6 +163,8 @@ public class TypesCtr implements Types {
      */
     private final ConcurrentMap<Class, ConcurrentMap<String, TypeProxy<Type>>> storage=
             new ConcurrentHashMap<Class, ConcurrentMap<String, TypeProxy<Type>>>();
+
+    private final ReentrantLock unknownTypesStorageLock = new ReentrantLock();
 
     /**
      * Map of encountered types which we don't know if it is an interface, class or annotation

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypesImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypesImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -56,7 +56,8 @@ public class TypesImpl implements TypeBuilder {
         Class<? extends Type> requestedType = getType(access);
 
         TypeProxy<Type> typeProxy = types.getHolder(name, requestedType);
-        synchronized(typeProxy) {
+        typeProxy.lock.lock();
+        try {
             final Type type = typeProxy.get();
             TypeImpl result;
             if (null == type) {
@@ -79,6 +80,8 @@ public class TypesImpl implements TypeBuilder {
                 }
                 return impl;
             }
+        } finally {
+            typeProxy.lock.unlock();
         }
     }
 

--- a/class-model/src/test/java/org/glassfish/hk2/classmodel/reflect/test/ClassModelTestsUtils.java
+++ b/class-model/src/test/java/org/glassfish/hk2/classmodel/reflect/test/ClassModelTestsUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Created by IntelliJ IDEA.
@@ -39,12 +40,14 @@ public class ClassModelTestsUtils {
 
     static Types types = null;
 
+    private final static ReentrantLock lock = new ReentrantLock();
     private final static ClassModelTestsUtils instance = new ClassModelTestsUtils();
 
 
     public static Types getTypes() throws IOException, InterruptedException {
-
-        synchronized(instance) {
+        
+        lock.lock();
+        try {
 
             if (types == null) {
                 File userDir = new File(System.getProperty("user.dir"));
@@ -80,6 +83,8 @@ public class ClassModelTestsUtils {
                     types = pc.getTypes();
                 }
             }
+        } finally {
+            lock.unlock();
         }
         return types;
     }

--- a/examples/operations/src/main/java/org/glassfish/examples/operations/application/internal/BankingServiceImpl.java
+++ b/examples/operations/src/main/java/org/glassfish/examples/operations/application/internal/BankingServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,7 @@ package org.glassfish.examples.operations.application.internal;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -51,53 +52,68 @@ public class BankingServiceImpl implements BankingService {
     
     @Inject
     private WithdrawalService withdrawerAgent;
-    
+
+    private final ReentrantLock lock = new ReentrantLock();
     private final Map<String, OperationHandle<DepositScope>> depositors = new HashMap<String, OperationHandle<DepositScope>>();
     private final Map<String, OperationHandle<WithdrawalScope>> withdrawers = new HashMap<String, OperationHandle<WithdrawalScope>>();
     
-    private synchronized OperationHandle<DepositScope> getDepositBankHandle(String bank) {
-        OperationHandle<DepositScope> depositor = depositors.get(bank);
-        if (depositor == null) {
-            // create and start it
-            depositor = manager.createOperation(DepositScopeImpl.INSTANCE);
-            depositors.put(bank, depositor);
+    private OperationHandle<DepositScope> getDepositBankHandle(String bank) {
+        lock.lock();
+        try {
+            OperationHandle<DepositScope> depositor = depositors.get(bank);
+            if (depositor == null) {
+                // create and start it
+                depositor = manager.createOperation(DepositScopeImpl.INSTANCE);
+                depositors.put(bank, depositor);
+            }
+
+            return depositor;
+        } finally {
+            lock.unlock();
         }
-        
-        return depositor;
     }
     
-    private synchronized OperationHandle<WithdrawalScope> getWithdrawerBankHandle(String bank) {
-        OperationHandle<WithdrawalScope> withdrawer = withdrawers.get(bank);
-        if (withdrawer == null) {
-            // create and start it
-            withdrawer = manager.createOperation(WithdrawalScopeImpl.INSTANCE);
-            withdrawers.put(bank, withdrawer);
+    private OperationHandle<WithdrawalScope> getWithdrawerBankHandle(String bank) {
+        lock.lock();
+        try {
+            OperationHandle<WithdrawalScope> withdrawer = withdrawers.get(bank);
+            if (withdrawer == null) {
+                // create and start it
+                withdrawer = manager.createOperation(WithdrawalScopeImpl.INSTANCE);
+                withdrawers.put(bank, withdrawer);
+            }
+
+            return withdrawer;
+        } finally {
+            lock.unlock();
         }
-        
-        return withdrawer;
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.examples.operations.application.BankingService#transferFunds(java.lang.String, long, java.lang.String, long, int)
      */
     @Override
-    public synchronized int transferFunds(String withdrawlBank, long withdrawlAccount,
+    public int transferFunds(String withdrawlBank, long withdrawlAccount,
             String depositorBank, long depositAccount, int funds) {
-        OperationHandle<DepositScope> depositor = getDepositBankHandle(depositorBank);
-        OperationHandle<WithdrawalScope> withdrawer = getWithdrawerBankHandle(withdrawlBank);
-        
-        // Set the context for the transfer
-        depositor.resume();
-        withdrawer.resume();
-        
-        // At this point the scopes are set properly, we can just call the service!
+        lock.lock();
         try {
-            return transferAgent.doTransfer(depositAccount, withdrawlAccount, funds);
-        }
-        finally {
-            // Turn off the two scopes
-            withdrawer.suspend();
-            depositor.suspend();
+            OperationHandle<DepositScope> depositor = getDepositBankHandle(depositorBank);
+            OperationHandle<WithdrawalScope> withdrawer = getWithdrawerBankHandle(withdrawlBank);
+
+            // Set the context for the transfer
+            depositor.resume();
+            withdrawer.resume();
+
+            // At this point the scopes are set properly, we can just call the service!
+            try {
+                return transferAgent.doTransfer(depositAccount, withdrawlAccount, funds);
+            } finally {
+                // Turn off the two scopes
+                withdrawer.suspend();
+                depositor.suspend();
+            }
+        } finally {
+            lock.unlock();
         }
         
     }

--- a/examples/operations/src/test/java/org/glassfish/examples/operations/tests/OperationsTest.java
+++ b/examples/operations/src/test/java/org/glassfish/examples/operations/tests/OperationsTest.java
@@ -65,7 +65,7 @@ public class OperationsTest {
     /**
      * Tests that we can transfer funds between ALICE and BOB
      */
-    @Test
+    //@Test
     public void testTransferBetweenBanks() {
         ServiceLocator locator = getServiceLocator();
         

--- a/examples/operations/src/test/java/org/glassfish/examples/operations/tests/OperationsTest.java
+++ b/examples/operations/src/test/java/org/glassfish/examples/operations/tests/OperationsTest.java
@@ -65,7 +65,7 @@ public class OperationsTest {
     /**
      * Tests that we can transfer funds between ALICE and BOB
      */
-    //@Test
+    @Test
     public void testTransferBetweenBanks() {
         ServiceLocator locator = getServiceLocator();
         

--- a/hk2-api/src/main/java/org/glassfish/hk2/api/MultiException.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/api/MultiException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,6 +20,7 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * This exception can contain multiple other exceptions.
@@ -34,7 +35,7 @@ public class MultiException extends HK2RuntimeException {
      * For serialization
      */
     private static final long serialVersionUID = 2112432697858621044L;
-    private final Object lock = new byte[0]; // byte[0] is an arbitrary type that is Serializable
+    private final ReentrantLock lock = new ReentrantLock();
     private final List<Throwable> throwables = new LinkedList<Throwable>();
     private boolean reportToErrorService = true;
 
@@ -106,8 +107,11 @@ public class MultiException extends HK2RuntimeException {
      * not return null, but may return an empty object
      */
     public List<Throwable> getErrors() {
-        synchronized (lock) {
+        lock.lock();
+        try {
             return new LinkedList<Throwable>(throwables);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -117,8 +121,11 @@ public class MultiException extends HK2RuntimeException {
      * @param error The exception to add
      */
     public void addError(Throwable error) {
-        synchronized (lock) {
+        lock.lock();
+        try {
             throwables.add(error);
+        } finally {
+            lock.unlock();
         }
     }
     

--- a/hk2-api/src/main/java/org/glassfish/hk2/internal/ServiceLocatorFactoryImpl.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/internal/ServiceLocatorFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.ServiceConfigurationError;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.api.ServiceLocatorFactory;
@@ -48,16 +49,16 @@ public class ServiceLocatorFactoryImpl extends ServiceLocatorFactory {
         }
             
     });
-    
-    private static final Object sLock = new Object();
+
+    private static final ReentrantLock sLock = new ReentrantLock();
     private static int name_count = 0;
     private static final String GENERATED_NAME_PREFIX = "__HK2_Generated_";
     
     private final static class DefaultGeneratorInitializer {
         private final static ServiceLocatorGenerator defaultGenerator = getGeneratorSecure();
     }
-    
-    private final Object lock = new Object();
+
+    private final ReentrantLock lock = new ReentrantLock();
     private final HashMap<String, ServiceLocator> serviceLocators = new HashMap<String, ServiceLocator>();
     private final HashSet<ServiceLocatorListener> listeners = new HashSet<ServiceLocatorListener>();
     
@@ -139,9 +140,12 @@ public class ServiceLocatorFactoryImpl extends ServiceLocatorFactory {
    */
   @Override
   public ServiceLocator find(String name) {
-    synchronized (lock) {
-      return serviceLocators.get(name);
-    }
+      try {
+          lock.lock();
+          return serviceLocators.get(name);
+      } finally {
+          lock.unlock();
+      }
   }
 
   /* (non-Javadoc)
@@ -155,7 +159,8 @@ public class ServiceLocatorFactoryImpl extends ServiceLocatorFactory {
   private void destroy(String name, ServiceLocator locator) {
       ServiceLocator killMe = null;
     
-      synchronized (lock) {
+      try {
+          lock.lock();
           if (name != null) {
               killMe = serviceLocators.remove(name);
           }
@@ -180,6 +185,8 @@ public class ServiceLocatorFactoryImpl extends ServiceLocatorFactory {
                   }
               }
           }
+      } finally {
+          lock.unlock();
       }
     
       if (killMe != null) {
@@ -203,8 +210,11 @@ public class ServiceLocatorFactoryImpl extends ServiceLocatorFactory {
     }
     
     private static String getGeneratedName() {
-        synchronized (sLock) {
+        sLock.lock();
+        try {
             return GENERATED_NAME_PREFIX + name_count++;
+        } finally {
+            sLock.unlock();
         }
         
     }
@@ -237,7 +247,8 @@ public class ServiceLocatorFactoryImpl extends ServiceLocatorFactory {
             Logger.getLogger().debug("ServiceFactoryImpl given create of " + name + " with parent " + parent +
                     " with generator " + generator + " and policy " + policy, new Throwable());
         }
-        synchronized (lock) {
+        lock.lock();
+        try {
             ServiceLocator retVal;
 
             if (name == null) {
@@ -276,6 +287,8 @@ public class ServiceLocatorFactoryImpl extends ServiceLocatorFactory {
                 Logger.getLogger().debug("ServiceFactoryImpl created locator " + retVal);
             }
             return retVal;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -293,7 +306,8 @@ public class ServiceLocatorFactoryImpl extends ServiceLocatorFactory {
     public void addListener(ServiceLocatorListener listener) {
         if (listener == null) throw new IllegalArgumentException();
         
-        synchronized (lock) {
+        lock.lock();
+        try {
             if (listeners.contains(listener)) return;
             
             try {
@@ -307,6 +321,8 @@ public class ServiceLocatorFactoryImpl extends ServiceLocatorFactory {
             }
             
             listeners.add(listener);
+        } finally {
+            lock.unlock();
         }
         
     }
@@ -315,8 +331,11 @@ public class ServiceLocatorFactoryImpl extends ServiceLocatorFactory {
     public void removeListener(ServiceLocatorListener listener) {
         if (listener == null) throw new IllegalArgumentException();
         
-        synchronized (lock) {
+        lock.lock();
+        try {
             listeners.remove(listener);
+        } finally {
+            lock.unlock();
         }
         
     }

--- a/hk2-api/src/main/java/org/glassfish/hk2/utilities/AliasDescriptor.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/utilities/AliasDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,6 +21,7 @@ import java.lang.reflect.Type;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Named;
 
@@ -62,6 +63,8 @@ public class AliasDescriptor<T> extends AbstractActiveDescriptor<T> {
      * For serialization
      */
     private static final long serialVersionUID = 2609895430798803508L;
+
+    private final ReentrantLock lock = new ReentrantLock();
 
     /**
      * The service locator.
@@ -226,28 +229,38 @@ public class AliasDescriptor<T> extends AbstractActiveDescriptor<T> {
      * @see org.glassfish.hk2.api.ActiveDescriptor#getQualifierAnnotations()
      */
     @Override
-    public synchronized Set<Annotation> getQualifierAnnotations() {
-        ensureInitialized();
+    public Set<Annotation> getQualifierAnnotations() {
+        lock.lock();
+        try {
+            ensureInitialized();
 
-        if (qualifiers == null) {
-            qualifiers = new HashSet<Annotation>(descriptor.getQualifierAnnotations());
-            if (getName() != null) {
-                qualifiers.add(new NamedImpl(getName()));
+            if (qualifiers == null) {
+                qualifiers = new HashSet<Annotation>(descriptor.getQualifierAnnotations());
+                if (getName() != null) {
+                    qualifiers.add(new NamedImpl(getName()));
+                }
             }
+            return qualifiers;
+        } finally {
+            lock.unlock();
         }
-        return qualifiers;
     }
     
     @Override
-    public synchronized Set<String> getQualifiers() {
-        if (qualifierNames != null) return qualifierNames;
-        
-        qualifierNames = new HashSet<String>(descriptor.getQualifiers());
-        if (getName() != null) {
-            qualifierNames.add(Named.class.getName());
+    public Set<String> getQualifiers() {
+        lock.lock();
+        try {
+            if (qualifierNames != null) return qualifierNames;
+
+            qualifierNames = new HashSet<String>(descriptor.getQualifiers());
+            if (getName() != null) {
+                qualifierNames.add(Named.class.getName());
+            }
+
+            return qualifierNames;
+        } finally {
+            lock.unlock();
         }
-        
-        return qualifierNames;
     }
 
     /* (non-Javadoc)
@@ -287,53 +300,59 @@ public class AliasDescriptor<T> extends AbstractActiveDescriptor<T> {
      * Ensure that this descriptor has been initialized.
      */
     @SuppressWarnings("unchecked")
-    private synchronized void ensureInitialized() {
-        if (!initialized) {
-            // reify the underlying descriptor if needed
-            if (!descriptor.isReified()) {
-                descriptor = (ActiveDescriptor<T>) locator.reifyDescriptor(descriptor);
-            }
+    private void ensureInitialized() {
+        lock.lock();
+        try {
+            if (!initialized) {
+                // reify the underlying descriptor if needed
+                if (!descriptor.isReified()) {
+                    descriptor = (ActiveDescriptor<T>) locator.reifyDescriptor(descriptor);
+                }
 
-            if (contract == null) {
+                if (contract == null) {
+                    initialized = true;
+                    return;
+                }
+
+                HK2Loader loader = descriptor.getLoader();
+
+                Type contractType = null;
+                try {
+                    if (loader != null) {
+                        contractType = loader.loadClass(contract);
+                    } else {
+                        Class<?> ic = descriptor.getImplementationClass();
+                        ClassLoader cl = null;
+                        if (ic != null) {
+                            cl = ic.getClassLoader();
+                        }
+                        if (cl == null) {
+                            cl = ClassLoader.getSystemClassLoader();
+                        }
+
+                        contractType = cl.loadClass(contract);
+                    }
+                } catch (ClassNotFoundException e) {
+                    // do nothing
+                }
+
+                super.addContractType(contractType);
+
                 initialized = true;
-                return;
             }
-
-            HK2Loader loader = descriptor.getLoader();
-
-            Type contractType = null;
-            try {
-                if (loader != null) {
-                    contractType = loader.loadClass(contract);
-                }
-                else {
-                    Class<?> ic = descriptor.getImplementationClass();
-                    ClassLoader cl = null;
-                    if (ic != null) {
-                        cl = ic.getClassLoader();
-                    }
-                    if (cl == null) {
-                        cl = ClassLoader.getSystemClassLoader();
-                    }
-
-                    contractType = cl.loadClass(contract);
-                }
-            }
-            catch (ClassNotFoundException e) {
-                // do nothing
-            }
-
-            super.addContractType(contractType);
-
-            initialized = true;
+        } finally {
+            lock.unlock();
         }
     }
     
     @Override
     public int hashCode() {
         int retVal;
-        synchronized (this) {
+        lock.lock();
+        try {
             retVal = descriptor.hashCode();
+        } finally {
+            lock.unlock();
         }
         
         if (getName() != null) {

--- a/hk2-api/src/main/java/org/glassfish/hk2/utilities/BuilderHelper.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/utilities/BuilderHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.Descriptor;
@@ -689,6 +690,7 @@ public class BuilderHelper {
 	public static <T> ServiceHandle<T> createConstantServiceHandle(final T obj) {
 	    return new ServiceHandle<T>() {
 	        private Object serviceData;
+            private final ReentrantLock lock = new ReentrantLock();
 
             @Override
             public T getService() {
@@ -711,13 +713,23 @@ public class BuilderHelper {
             }
             
             @Override
-            public synchronized void setServiceData(Object serviceData) {
-                this.serviceData = serviceData;
+            public void setServiceData(Object serviceData) {
+                lock.lock();
+                try {
+                    this.serviceData = serviceData;
+                } finally {
+                    lock.unlock();
+                }
             }
 
             @Override
-            public synchronized Object getServiceData() {
-                return serviceData;
+            public Object getServiceData() {
+                lock.lock();
+                try {
+                    return serviceData;
+                } finally {
+                    lock.unlock();
+                }
             }
 
             @Override

--- a/hk2-api/src/main/java/org/glassfish/hk2/utilities/DescriptorImpl.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/utilities/DescriptorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,6 +31,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Singleton;
 
@@ -79,6 +80,7 @@ public class DescriptorImpl implements Descriptor, Externalizable {
     private final static Set<String> EMPTY_CONTRACTS_SET = Collections.emptySet();
     private final static Set<String> EMPTY_QUALIFIER_SET = Collections.emptySet();
     private final static Map<String, List<String>> EMPTY_METADATAS_MAP = Collections.emptyMap();
+    private final ReentrantLock lock = new ReentrantLock();
 	
 	private Set<String> contracts;
 	private String implementation;
@@ -203,19 +205,29 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	}
 	
 	@Override
-	public synchronized Set<String> getAdvertisedContracts() {
-	    if (contracts == null) return EMPTY_CONTRACTS_SET;
-		return Collections.unmodifiableSet(contracts);
+	public Set<String> getAdvertisedContracts() {
+        lock.lock();
+        try {
+            if (contracts == null) return EMPTY_CONTRACTS_SET;
+            return Collections.unmodifiableSet(contracts);
+        } finally {
+            lock.unlock();
+        }
 	}
 	
 	/**
 	 * Adds an advertised contract to the set of contracts advertised by this descriptor
 	 * @param addMe The contract to add.  May not be null
 	 */
-	public synchronized void addAdvertisedContract(String addMe) {
-	    if (addMe == null) return;
-	    if (contracts == null) contracts = new LinkedHashSet<String>();
-	    contracts.add(addMe);
+	public void addAdvertisedContract(String addMe) {
+        lock.lock();
+        try {
+            if (addMe == null) return;
+            if (contracts == null) contracts = new LinkedHashSet<String>();
+            contracts.add(addMe);
+        } finally {
+            lock.unlock();
+        }
 	}
 	
 	/**
@@ -223,54 +235,94 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @param removeMe The contract to remove.  May not be null
 	 * @return true if removeMe was removed from the set
 	 */
-	public synchronized boolean removeAdvertisedContract(String removeMe) {
-	    if (removeMe == null || contracts == null) return false;
-	    return contracts.remove(removeMe);
+	public boolean removeAdvertisedContract(String removeMe) {
+        lock.lock();
+        try {
+            if (removeMe == null || contracts == null) return false;
+            return contracts.remove(removeMe);
+        } finally {
+            lock.unlock();
+        }
 	}
 
 	@Override
-	public synchronized String getImplementation() {
-		return implementation;
+	public String getImplementation() {
+        lock.lock();
+        try {
+            return implementation;
+        } finally {
+            lock.unlock();
+        }
 	}
 	
 	/**
 	 * Sets the implementation
 	 * @param implementation The implementation this descriptor should have
 	 */
-    public synchronized void setImplementation(String implementation) {
-        this.implementation = implementation;
+    public void setImplementation(String implementation) {
+        lock.lock();
+        try {
+            this.implementation = implementation;
+        } finally {
+            lock.unlock();
+        }
     }
 
 	@Override
-	public synchronized String getScope() {
-		return scope;
+	public String getScope() {
+        lock.lock();
+        try {
+            return scope;
+        } finally {
+            lock.unlock();
+        }
 	}
 	
 	/**
 	 * Sets the scope this descriptor should have
 	 * @param scope The scope of this descriptor
 	 */
-	public synchronized void setScope(String scope) {
-	    this.scope = scope;
+	public void setScope(String scope) {
+        lock.lock();
+        try {
+            this.scope = scope;
+        } finally {
+            lock.unlock();
+        }
 	}
 
 	@Override
-	public synchronized String getName() {
-		return name;
+	public String getName() {
+        lock.lock();
+        try {
+            return name;
+        } finally {
+            lock.unlock();
+        }
 	}
 	
 	/**
 	 * Sets the name this descriptor should have
 	 * @param name The name for this descriptor
 	 */
-	public synchronized void setName(String name) {
-	    this.name = name;
-	}
+    public void setName(String name) {
+        lock.lock();
+        try {
+            this.name = name;
+        } finally {
+            lock.unlock();
+        }
+    }
 
 	@Override
-	public synchronized Set<String> getQualifiers() {
-	    if (qualifiers == null) return EMPTY_QUALIFIER_SET;
-		return Collections.unmodifiableSet(qualifiers);
+	public Set<String> getQualifiers() {
+        lock.lock();
+        try {
+            if (qualifiers == null) return EMPTY_QUALIFIER_SET;
+            return Collections.unmodifiableSet(qualifiers);
+        } finally {
+            lock.unlock();
+        }
 	}
 	
 	/**
@@ -278,10 +330,15 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * 
 	 * @param addMe The fully qualified class name of the qualifier to add.  May not be null
 	 */
-	public synchronized void addQualifier(String addMe) {
-	    if (addMe == null) return;
-	    if (qualifiers == null) qualifiers = new LinkedHashSet<String>();
-	    qualifiers.add(addMe);
+	public void addQualifier(String addMe) {
+        lock.lock();
+        try {
+            if (addMe == null) return;
+            if (qualifiers == null) qualifiers = new LinkedHashSet<String>();
+            qualifiers.add(addMe);
+        } finally {
+            lock.unlock();
+        }
 	}
 	
 	/**
@@ -290,44 +347,74 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @param removeMe The fully qualifier class name of the qualifier to remove.  May not be null
 	 * @return true if the given qualifier was removed
 	 */
-	public synchronized boolean removeQualifier(String removeMe) {
-	    if (removeMe == null) return false;
-	    if (qualifiers == null) return false;
-	    return qualifiers.remove(removeMe);
+	public boolean removeQualifier(String removeMe) {
+        lock.lock();
+        try {
+            if (removeMe == null) return false;
+            if (qualifiers == null) return false;
+            return qualifiers.remove(removeMe);
+        } finally {
+            lock.unlock();
+        }
 	}
 
     @Override
-    public synchronized DescriptorType getDescriptorType() {
-        return descriptorType;
+    public DescriptorType getDescriptorType() {
+        lock.lock();
+        try {
+            return descriptorType;
+        } finally {
+            lock.unlock();
+        }
     }
     
     /**
      * Sets the descriptor type
      * @param descriptorType The descriptor type.  May not be null
      */
-    public synchronized void setDescriptorType(DescriptorType descriptorType) {
-        if (descriptorType == null) throw new IllegalArgumentException();
-        this.descriptorType = descriptorType;
+    public void setDescriptorType(DescriptorType descriptorType) {
+        lock.lock();
+        try {
+            if (descriptorType == null) throw new IllegalArgumentException();
+            this.descriptorType = descriptorType;
+        } finally {
+            lock.unlock();
+        }
     }
     
     @Override
-    public synchronized DescriptorVisibility getDescriptorVisibility() {
-        return descriptorVisibility;
+    public DescriptorVisibility getDescriptorVisibility() {
+        lock.lock();
+        try {
+            return descriptorVisibility;
+        } finally {
+            lock.unlock();
+        }
     }
     
     /**
      * Sets the descriptor visilibity
      * @param descriptorVisibility The visibility this descriptor should have
      */
-    public synchronized void setDescriptorVisibility(DescriptorVisibility descriptorVisibility) {
-        if (descriptorVisibility == null) throw new IllegalArgumentException();
-        this.descriptorVisibility = descriptorVisibility;
+    public void setDescriptorVisibility(DescriptorVisibility descriptorVisibility) {
+        lock.lock();
+        try {
+            if (descriptorVisibility == null) throw new IllegalArgumentException();
+            this.descriptorVisibility = descriptorVisibility;
+        } finally {
+            lock.unlock();
+        }
     }
 
 	@Override
-	public synchronized Map<String, List<String>> getMetadata() {
-	    if (metadatas == null) return EMPTY_METADATAS_MAP;
-		return Collections.unmodifiableMap(metadatas);
+	public Map<String, List<String>> getMetadata() {
+        lock.lock();
+        try {
+            if (metadatas == null) return EMPTY_METADATAS_MAP;
+            return Collections.unmodifiableMap(metadatas);
+        } finally {
+            lock.unlock();
+        }
 	}
 	
 	/**
@@ -339,15 +426,19 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @param metadata The non-null metadata that this descriptor
 	 * should have
 	 */
-	public synchronized void setMetadata(Map<String, List<String>> metadata) {
-	    if (metadatas == null) {
-	        metadatas = new LinkedHashMap<String, List<String>>();
-	    }
-	    else {
-	        metadatas.clear();
-	    }
-	    
-	    metadatas.putAll(ReflectionHelper.deepCopyMetadata(metadata));
+	public void setMetadata(Map<String, List<String>> metadata) {
+        lock.lock();
+        try {
+            if (metadatas == null) {
+                metadatas = new LinkedHashMap<String, List<String>>();
+            } else {
+                metadatas.clear();
+            }
+
+            metadatas.putAll(ReflectionHelper.deepCopyMetadata(metadata));
+        } finally {
+            lock.unlock();
+        }
 	}
 	
 	/**
@@ -357,10 +448,15 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @param metadata The non-null but possibly empty list of fields
 	 * to add to the metadata map
 	 */
-	public synchronized void addMetadata(Map<String, List<String>> metadata) {
-	    if (metadatas == null) metadatas = new LinkedHashMap<String, List<String>>();
-	    
-        metadatas.putAll(ReflectionHelper.deepCopyMetadata(metadata));
+	public void addMetadata(Map<String, List<String>> metadata) {
+        lock.lock();
+        try {
+            if (metadatas == null) metadatas = new LinkedHashMap<String, List<String>>();
+
+            metadatas.putAll(ReflectionHelper.deepCopyMetadata(metadata));
+        } finally {
+            lock.unlock();
+        }
     }
 	
 	/**
@@ -370,9 +466,14 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * not contain the character '='
 	 * @param value The value to add.  May not be null
 	 */
-	public synchronized void addMetadata(String key, String value) {
-	    if (metadatas == null) metadatas = new LinkedHashMap<String, List<String>>();
-	    ReflectionHelper.addMetadata(metadatas, key, value);
+	public void addMetadata(String key, String value) {
+        lock.lock();
+        try {
+            if (metadatas == null) metadatas = new LinkedHashMap<String, List<String>>();
+            ReflectionHelper.addMetadata(metadatas, key, value);
+        } finally {
+            lock.unlock();
+        }
 	}
 	
 	/**
@@ -383,9 +484,14 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @param value The value to remove.  May not be null
 	 * @return true if the value was removed
 	 */
-	public synchronized boolean removeMetadata(String key, String value) {
-	    if (metadatas == null) return false;
-	    return ReflectionHelper.removeMetadata(metadatas, key, value);
+	public boolean removeMetadata(String key, String value) {
+        lock.lock();
+        try {
+            if (metadatas == null) return false;
+            return ReflectionHelper.removeMetadata(metadatas, key, value);
+        } finally {
+            lock.unlock();
+        }
 	}
 	
 	/**
@@ -394,60 +500,100 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @param key The key of the metadata values to remove
 	 * @return true if any value was removed
 	 */
-	public synchronized boolean removeAllMetadata(String key) {
-	    if (metadatas == null) return false;
-	    return ReflectionHelper.removeAllMetadata(metadatas, key);
+	public boolean removeAllMetadata(String key) {
+        lock.lock();
+        try {
+            if (metadatas == null) return false;
+            return ReflectionHelper.removeAllMetadata(metadatas, key);
+        } finally {
+            lock.unlock();
+        }
 	}
 	
 	/**
      * Removes all metadata values
      */
-    public synchronized void clearMetadata() {
-        metadatas = null;
+    public void clearMetadata() {
+        lock.lock();
+        try {
+            metadatas = null;
+        } finally {
+            lock.unlock();
+        }
     }
 	
 	/* (non-Javadoc)
      * @see org.glassfish.hk2.api.Descriptor#getLoader()
      */
     @Override
-    public synchronized HK2Loader getLoader() {
-        return loader;
+    public HK2Loader getLoader() {
+        lock.lock();
+        try {
+            return loader;
+        } finally {
+            lock.unlock();
+        }
     }
     
     /**
      * Sets the loader to use with this descriptor
      * @param loader The loader to use with this descriptor
      */
-    public synchronized void setLoader(HK2Loader loader) {
-        this.loader = loader;
+    public void setLoader(HK2Loader loader) {
+        lock.lock();
+        try {
+            this.loader = loader;
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override
-    public synchronized int getRanking() {
-        return rank;
+    public int getRanking() {
+        lock.lock();
+        try {
+            return rank;
+        } finally {
+            lock.unlock();
+        }
     }
     
     /* (non-Javadoc)
      * @see org.glassfish.hk2.api.Descriptor#setRanking(int)
      */
     @Override
-    public synchronized int setRanking(int ranking) {
-        int retVal = rank;
-        rank = ranking;
-        return retVal;
+    public int setRanking(int ranking) {
+        lock.lock();
+        try {
+            int retVal = rank;
+            rank = ranking;
+            return retVal;
+        } finally {
+            lock.unlock();
+        }
     }
 	
 	@Override
-	public synchronized Long getServiceId() {
-		return id;
+	public Long getServiceId() {
+        lock.lock();
+        try {
+            return id;
+        } finally {
+            lock.unlock();
+        }
 	}
 	
 	/**
 	 * Sets the service id for this descriptor
 	 * @param id the service id for this descriptor
 	 */
-	public synchronized void setServiceId(Long id) {
-	    this.id = id;
+	public void setServiceId(Long id) {
+        lock.lock();
+        try {
+            this.id = id;
+        } finally {
+            lock.unlock();
+        }
 	}
 	
 	@Override
@@ -501,16 +647,26 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	}
 	
 	@Override
-	public synchronized Long getLocatorId() {
-	    return locatorId;
+	public Long getLocatorId() {
+        lock.lock();
+        try {
+            return locatorId;
+        } finally {
+            lock.unlock();
+        }
 	}
 	
 	/**
 	 * Sets the locator id for this descriptor
 	 * @param locatorId the locator id for this descriptor
 	 */
-	public synchronized void setLocatorId(Long locatorId) {
-	    this.locatorId = locatorId;
+	public void setLocatorId(Long locatorId) {
+        lock.lock();
+        try {
+            this.locatorId = locatorId;
+        } finally {
+            lock.unlock();
+        }
 	}
 	
 	public int hashCode() {
@@ -724,14 +880,19 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	    
 	}
 	
-	public synchronized String toString() {
-        StringBuffer sb = new StringBuffer("Descriptor(");
-        
-        pretty(sb, this);
-        
-        sb.append(")");
-        
-        return sb.toString();
+	public String toString() {
+        lock.lock();
+        try {
+            StringBuffer sb = new StringBuffer("Descriptor(");
+
+            pretty(sb, this);
+
+            sb.append(")");
+
+            return sb.toString();
+        } finally {
+            lock.unlock();
+        }
 	}
 	
 	/**

--- a/hk2-api/src/main/java/org/glassfish/hk2/utilities/ImmediateContext.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/utilities/ImmediateContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,6 +23,8 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -48,6 +50,9 @@ import org.glassfish.hk2.internal.ImmediateLocalLocatorFilter;
  */
 @Singleton @Visibility(DescriptorVisibility.LOCAL)
 public class ImmediateContext implements Context<Immediate>{
+
+    private final ReentrantLock lock = new ReentrantLock();
+    private final Condition notEmpty = lock.newCondition();
     private final HashMap<ActiveDescriptor<?>, HandleAndService> currentImmediateServices = new HashMap<ActiveDescriptor<?>, HandleAndService>();
     private final HashMap<ActiveDescriptor<?>, Long> creating = new HashMap<ActiveDescriptor<?>, Long>();
     
@@ -76,7 +81,8 @@ public class ImmediateContext implements Context<Immediate>{
             ServiceHandle<?> root) {
         U retVal = null;
         
-        synchronized (this) {
+        lock.lock();
+        try {
             HandleAndService has = currentImmediateServices.get(activeDescriptor);
             if (has != null) {
                 return (U) has.getService();
@@ -91,7 +97,7 @@ public class ImmediateContext implements Context<Immediate>{
                 }
                 
                 try {
-                    this.wait();
+                    notEmpty.await();
                 }
                 catch (InterruptedException ie) {
                     throw new MultiException(ie);
@@ -105,13 +111,16 @@ public class ImmediateContext implements Context<Immediate>{
             }
             
             creating.put(activeDescriptor, Thread.currentThread().getId());
+        } finally {
+            lock.unlock();
         }
         
         try {
             retVal = activeDescriptor.create(root);
         }
         finally {
-            synchronized (this) {
+            lock.lock();
+            try {
                 ServiceHandle<?> discoveredRoot = null;
                 if (root != null) {
                     if (root.getActiveDescriptor().equals(activeDescriptor)) {
@@ -125,6 +134,8 @@ public class ImmediateContext implements Context<Immediate>{
                 
                 creating.remove(activeDescriptor);
                 this.notifyAll();
+            } finally {
+                lock.unlock();
             }
             
         }
@@ -137,8 +148,13 @@ public class ImmediateContext implements Context<Immediate>{
      * @return true if this service has been created
      */
     @Override
-    public synchronized boolean containsKey(ActiveDescriptor<?> descriptor) {
-        return currentImmediateServices.containsKey(descriptor);
+    public boolean containsKey(ActiveDescriptor<?> descriptor) {
+        lock.lock();
+        try {
+            return currentImmediateServices.containsKey(descriptor);
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override
@@ -158,7 +174,8 @@ public class ImmediateContext implements Context<Immediate>{
             errorHandlers = locator.getAllServices(ImmediateErrorHandler.class);
         }
         
-        synchronized (this) {
+        lock.lock();
+        try {
             HandleAndService has = currentImmediateServices.remove(descriptor);
             Object instance = has.getService();
         
@@ -176,6 +193,8 @@ public class ImmediateContext implements Context<Immediate>{
                 }
             }
             
+        } finally {
+            lock.unlock();
         }
         
     }
@@ -197,7 +216,8 @@ public class ImmediateContext implements Context<Immediate>{
     public void shutdown() {
         List<ImmediateErrorHandler> errorHandlers = locator.getAllServices(ImmediateErrorHandler.class);
         
-        synchronized (this) {
+        lock.lock();
+        try {
             for (Map.Entry<ActiveDescriptor<?>, HandleAndService> entry :
                 new HashSet<Map.Entry<ActiveDescriptor<?>, HandleAndService>>(currentImmediateServices.entrySet())) {
                 HandleAndService has = entry.getValue();
@@ -214,6 +234,8 @@ public class ImmediateContext implements Context<Immediate>{
             }
             
             
+        } finally {
+            lock.unlock();
         }
     }
     
@@ -250,11 +272,12 @@ public class ImmediateContext implements Context<Immediate>{
         LinkedHashSet<ActiveDescriptor<?>> newFullSet = new LinkedHashSet<ActiveDescriptor<?>>(inScopeAndInThisLocator);
         LinkedHashSet<ActiveDescriptor<?>> addMe = new LinkedHashSet<ActiveDescriptor<?>>();
         
-        synchronized (this) {
+        lock.lock();
+        try {
             // First thing to do is wait until all the things in-flight have gone
             while (creating.size() > 0) {
                 try {
-                    this.wait();
+                    notEmpty.await();
                 }
                 catch (InterruptedException ie) {
                     throw new RuntimeException(ie);
@@ -282,6 +305,8 @@ public class ImmediateContext implements Context<Immediate>{
                     destroyOne(gone, errorHandlers);
                 }
             }
+        } finally {
+            lock.unlock();
         }
         
         for (ActiveDescriptor<?> ad : addMe) {

--- a/hk2-api/src/main/java/org/glassfish/hk2/utilities/ImmediateContext.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/utilities/ImmediateContext.java
@@ -133,7 +133,7 @@ public class ImmediateContext implements Context<Immediate>{
                 }
                 
                 creating.remove(activeDescriptor);
-                this.notifyAll();
+                notEmpty.signalAll();
             } finally {
                 lock.unlock();
             }

--- a/hk2-configuration/hk2-integration/src/main/java/org/glassfish/hk2/configuration/internal/ConfigurationListener.java
+++ b/hk2-configuration/hk2-integration/src/main/java/org/glassfish/hk2/configuration/internal/ConfigurationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -83,8 +84,8 @@ public class ConfigurationListener implements BeanDatabaseUpdateListener {
     
     private final ConcurrentHashMap<String, ModificationInformation> typeInformation = 
             new ConcurrentHashMap<String, ModificationInformation>();
-    
-    private final Object progenitorLock = new Object();
+
+    private final ReentrantLock progenitorLock = new ReentrantLock();
     private HashSet<ActiveDescriptor<?>> allProgenitors =
             new HashSet<ActiveDescriptor<?>>();
     
@@ -329,8 +330,11 @@ public class ConfigurationListener implements BeanDatabaseUpdateListener {
         
         List<ActiveDescriptor<?>> progenitors = locator.getDescriptors(new NoNameTypeFilter(locator, null, null));
         
-        synchronized (progenitorLock) {
+        progenitorLock.lock();
+        try {
             allProgenitors.addAll(progenitors);
+        } finally {
+            progenitorLock.unlock();
         }
         config.addActiveDescriptor(DescriptorListener.class);
         
@@ -524,7 +528,8 @@ public class ConfigurationListener implements BeanDatabaseUpdateListener {
         final LinkedList<ActiveDescriptor<?>> addedList = new LinkedList<ActiveDescriptor<?>>();
         final LinkedList<ActiveDescriptor<?>> removedList = new LinkedList<ActiveDescriptor<?>>();
         
-        synchronized (progenitorLock) {
+        progenitorLock.lock();
+        try {
             HashSet<ActiveDescriptor<?>> removed = new HashSet<ActiveDescriptor<?>>(allProgenitors);
             
             progenitors = locator.getDescriptors(new NoNameTypeFilter(locator, null, null));
@@ -553,6 +558,8 @@ public class ConfigurationListener implements BeanDatabaseUpdateListener {
                 }
             }
             
+        } finally {
+            progenitorLock.unlock();
         }
         
         if (!addedList.isEmpty() || !removedList.isEmpty()) {

--- a/hk2-configuration/hk2-integration/src/main/java/org/glassfish/hk2/configuration/internal/ConfiguredByContext.java
+++ b/hk2-configuration/hk2-integration/src/main/java/org/glassfish/hk2/configuration/internal/ConfiguredByContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Singleton;
 
@@ -42,7 +43,7 @@ public class ConfiguredByContext implements Context<ConfiguredBy> {
 
     private final static ThreadLocal<ActiveDescriptor<?>> workingOn = ThreadLocal.withInitial(() -> null);
 
-    private final Object lock = new Object();
+    private final ReentrantLock lock = new ReentrantLock();
     private final Map<ActiveDescriptor<?>, Object> db = new HashMap<>();
 
     /* (non-Javadoc)
@@ -76,7 +77,8 @@ public class ConfiguredByContext implements Context<ConfiguredBy> {
     @SuppressWarnings("unchecked")
     private <U> U internalFindOrCreate(ActiveDescriptor<U> activeDescriptor,
             ServiceHandle<?> root) {
-        synchronized (lock) {
+        lock.lock();
+        try {
             U retVal = (U) db.get(activeDescriptor);
             if (retVal != null) return retVal;
 
@@ -88,6 +90,8 @@ public class ConfiguredByContext implements Context<ConfiguredBy> {
             db.put(activeDescriptor, retVal);
 
             return retVal;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -96,8 +100,11 @@ public class ConfiguredByContext implements Context<ConfiguredBy> {
      */
     @Override
     public boolean containsKey(ActiveDescriptor<?> descriptor) {
-        synchronized (lock) {
+        lock.lock();
+        try {
             return db.containsKey(descriptor);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -107,11 +114,14 @@ public class ConfiguredByContext implements Context<ConfiguredBy> {
     @SuppressWarnings("unchecked")
     @Override
     public void destroyOne(ActiveDescriptor<?> descriptor) {
-        synchronized (lock) {
+        lock.lock();
+        try {
             Object destroyMe = db.remove(descriptor);
             if (destroyMe == null) return;
 
             ((ActiveDescriptor<Object>) descriptor).dispose(destroyMe);
+        } finally {
+            lock.unlock();
         }
 
     }
@@ -137,11 +147,14 @@ public class ConfiguredByContext implements Context<ConfiguredBy> {
      */
     @Override
     public void shutdown() {
-        synchronized (lock) {
+        lock.lock();
+        try {
             Set<ActiveDescriptor<?>> activeDescriptors = new HashSet<>(db.keySet());
             for (ActiveDescriptor<?> killMe : activeDescriptors) {
                 destroyOne(killMe);
             }
+        } finally {
+            lock.unlock();
         }
 
     }
@@ -151,8 +164,11 @@ public class ConfiguredByContext implements Context<ConfiguredBy> {
     }
 
     /* package */ Object findOnly(ActiveDescriptor<?> descriptor) {
-        synchronized (lock) {
+        lock.lock();
+        try {
             return db.get(descriptor);
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/hk2-configuration/hk2-integration/src/main/java/org/glassfish/hk2/configuration/internal/ConfiguredByInjectionResolver.java
+++ b/hk2-configuration/hk2-integration/src/main/java/org/glassfish/hk2/configuration/internal/ConfiguredByInjectionResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -48,7 +49,8 @@ public class ConfiguredByInjectionResolver implements
     
     @Inject
     private ConfiguredByContext context;
-    
+
+    private final ReentrantLock lock = new ReentrantLock();
     private final ConcurrentHashMap<ActiveDescriptor<?>, BeanInfo> beanMap = new ConcurrentHashMap<ActiveDescriptor<?>, BeanInfo>(); 
     
     private static String getParameterNameFromConstructor(Constructor<?> cnst, int position) {
@@ -95,38 +97,40 @@ public class ConfiguredByInjectionResolver implements
      * @see org.glassfish.hk2.api.InjectionResolver#resolve(org.glassfish.hk2.api.Injectee, org.glassfish.hk2.api.ServiceHandle)
      */
     @Override
-    public synchronized Object resolve(Injectee injectee, ServiceHandle<?> root) {
-        ActiveDescriptor<?> injecteeParent = injectee.getInjecteeDescriptor();
-        if (injecteeParent == null) return systemResolver.resolve(injectee, root);
-        
-        AnnotatedElement ae = injectee.getParent();
-        if (ae == null) return systemResolver.resolve(injectee, root);
-        
-        String parameterName = null;
-        if (ae instanceof Field) {
-            parameterName = BeanUtilities.getParameterNameFromField((Field) ae, false);
+    public Object resolve(Injectee injectee, ServiceHandle<?> root) {
+        lock.lock();
+        try {
+            ActiveDescriptor<?> injecteeParent = injectee.getInjecteeDescriptor();
+            if (injecteeParent == null) return systemResolver.resolve(injectee, root);
+
+            AnnotatedElement ae = injectee.getParent();
+            if (ae == null) return systemResolver.resolve(injectee, root);
+
+            String parameterName = null;
+            if (ae instanceof Field) {
+                parameterName = BeanUtilities.getParameterNameFromField((Field) ae, false);
+            } else if (ae instanceof Constructor) {
+                parameterName = getParameterNameFromConstructor((Constructor<?>) ae, injectee.getPosition());
+            } else if (ae instanceof Method) {
+                parameterName = getParameterNameFromMethod((Method) ae, injectee.getPosition());
+            } else {
+                return systemResolver.resolve(injectee, root);
+            }
+
+            if (parameterName == null) return systemResolver.resolve(injectee, root);
+
+            ActiveDescriptor<?> workingOn = context.getWorkingOn();
+            if (workingOn == null) return systemResolver.resolve(injectee, root);
+
+            BeanInfo beanInfo = beanMap.get(workingOn);
+            if (beanInfo == null) {
+                throw new IllegalStateException("Could not find a configuration bean for " + injectee + " with descriptor " + workingOn);
+            }
+
+            return BeanUtilities.getBeanPropertyValue(injectee.getRequiredType(), parameterName, beanInfo);
+        } finally {
+            lock.unlock();
         }
-        else if (ae instanceof Constructor) {
-            parameterName = getParameterNameFromConstructor((Constructor<?>) ae, injectee.getPosition());
-        }
-        else if (ae instanceof Method){
-            parameterName = getParameterNameFromMethod((Method) ae, injectee.getPosition());
-        }
-        else {
-            return systemResolver.resolve(injectee, root);
-        }
-        
-        if (parameterName == null) return systemResolver.resolve(injectee, root);
-        
-        ActiveDescriptor<?> workingOn = context.getWorkingOn();
-        if (workingOn == null) return systemResolver.resolve(injectee, root);
-        
-        BeanInfo beanInfo = beanMap.get(workingOn);
-        if (beanInfo == null) {
-            throw new IllegalStateException("Could not find a configuration bean for " + injectee + " with descriptor " + workingOn);
-        }
-        
-        return BeanUtilities.getBeanPropertyValue(injectee.getRequiredType(), parameterName, beanInfo);
     }
 
     /* (non-Javadoc)
@@ -145,14 +149,24 @@ public class ConfiguredByInjectionResolver implements
         return true;
     }
     
-    /* package */ synchronized BeanInfo addBean(ActiveDescriptor<?> descriptor, Object bean, String type, Object metadata) {
-        BeanInfo retVal = new BeanInfo(type, descriptor.getName(), bean, metadata);
-        beanMap.put(descriptor, retVal);
-        return retVal;
+    /* package */ BeanInfo addBean(ActiveDescriptor<?> descriptor, Object bean, String type, Object metadata) {
+        lock.lock();
+        try {
+            BeanInfo retVal = new BeanInfo(type, descriptor.getName(), bean, metadata);
+            beanMap.put(descriptor, retVal);
+            return retVal;
+        } finally {
+            lock.unlock();
+        }
     }
     
-    /* package */ synchronized void removeBean(ActiveDescriptor<?> descriptor) {
-        beanMap.remove(descriptor);
+    /* package */ void removeBean(ActiveDescriptor<?> descriptor) {
+        lock.lock();
+        try {
+            beanMap.remove(descriptor);
+        } finally {
+            lock.unlock();
+        }
     }
     
     @Override

--- a/hk2-configuration/hk2-integration/src/main/java/org/glassfish/hk2/configuration/internal/DelegatingNamedActiveDescriptor.java
+++ b/hk2-configuration/hk2-integration/src/main/java/org/glassfish/hk2/configuration/internal/DelegatingNamedActiveDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Named;
 
@@ -186,8 +187,8 @@ public class DelegatingNamedActiveDescriptor implements
     public Long getLocatorId() {
         return null;
     }
-    
-    private Object lock = new Object();
+
+    private final ReentrantLock lock = new ReentrantLock();
     private Object cache;
     private boolean isSet = false;
 
@@ -196,8 +197,11 @@ public class DelegatingNamedActiveDescriptor implements
      */
     @Override
     public Object getCache() {
-        synchronized (lock) {
+        lock.lock();
+        try {
             return cache;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -206,8 +210,11 @@ public class DelegatingNamedActiveDescriptor implements
      */
     @Override
     public boolean isCacheSet() {
-        synchronized (lock) {
+        lock.lock();
+        try {
             return isSet;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -216,9 +223,12 @@ public class DelegatingNamedActiveDescriptor implements
      */
     @Override
     public void setCache(Object cacheMe) {
-        synchronized (lock) {
+        lock.lock();
+        try {
             isSet = true;
             cache = cacheMe;
+        } finally {
+            lock.unlock();
         }
 
     }
@@ -228,9 +238,12 @@ public class DelegatingNamedActiveDescriptor implements
      */
     @Override
     public void releaseCache() {
-        synchronized (lock) {
+        lock.lock();
+        try {
             cache = null;
             isSet = false;
+        } finally {
+            lock.unlock();
         }
 
     }

--- a/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/BeanDatabaseImpl.java
+++ b/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/BeanDatabaseImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.configuration.hub.api.BeanDatabase;
 import org.glassfish.hk2.configuration.hub.api.Instance;
@@ -32,6 +33,7 @@ import org.glassfish.hk2.configuration.hub.api.Type;
  */
 public class BeanDatabaseImpl implements BeanDatabase {
     private final long revision;
+    private final ReentrantLock lock = new ReentrantLock();
     private final HashMap<String, TypeImpl> types = new HashMap<String, TypeImpl>();
 
     /**
@@ -53,27 +55,42 @@ public class BeanDatabaseImpl implements BeanDatabase {
      * @see org.glassfish.hk2.configuration.hub.api.BeanDatabase#getAllTypes()
      */
     @Override
-    public synchronized Set<Type> getAllTypes() {
-        return Collections.unmodifiableSet(new HashSet<Type>(types.values()));
+    public Set<Type> getAllTypes() {
+        lock.lock();
+        try {
+            return Collections.unmodifiableSet(new HashSet<Type>(types.values()));
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.configuration.hub.api.BeanDatabase#getInstance(java.lang.String, java.lang.Object)
      */
     @Override
-    public synchronized Instance getInstance(String type, String instanceKey) {
-        Type t = getType(type);
-        if (t == null) return null;
+    public Instance getInstance(String type, String instanceKey) {
+        lock.lock();
+        try {
+            Type t = getType(type);
+            if (t == null) return null;
 
-        return t.getInstance(instanceKey);
+            return t.getInstance(instanceKey);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.configuration.hub.api.BeanDatabase#getType(java.lang.String)
      */
     @Override
-    public synchronized Type getType(String type) {
-        return types.get(type);
+    public Type getType(String type) {
+        lock.lock();
+        try {
+            return types.get(type);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* package */ long getRevision() {

--- a/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/HubImpl.java
+++ b/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/HubImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Inject;
 
@@ -47,8 +48,8 @@ import org.jvnet.hk2.annotations.Service;
 @Visibility(DescriptorVisibility.LOCAL)
 public class HubImpl implements Hub {
     private static final AtomicLong revisionCounter = new AtomicLong(1);
-    
-    private final Object lock = new Object();
+
+    private final ReentrantLock lock = new ReentrantLock();
     private BeanDatabaseImpl currentDatabase = new BeanDatabaseImpl(revisionCounter.getAndIncrement());
     
     @Inject
@@ -59,8 +60,11 @@ public class HubImpl implements Hub {
      */
     @Override
     public BeanDatabase getCurrentDatabase() {
-        synchronized (lock) {
+        lock.lock();
+        try {
             return currentDatabase;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -69,15 +73,19 @@ public class HubImpl implements Hub {
      */
     @Override
     public WriteableBeanDatabase getWriteableDatabaseCopy() {
-        synchronized (lock) {
+        lock.lock();
+        try {
             return new WriteableBeanDatabaseImpl(this, currentDatabase);
+        } finally {
+            lock.unlock();
         }
     }
     
     private int inTransaction = 0;
     
     /* package */ LinkedList<BeanDatabaseUpdateListener> prepareCurrentDatabase(WriteableBeanDatabaseImpl writeableDatabase, Object commitMessage, List<Change> changes) {
-        synchronized (lock) {
+        lock.lock();
+        try {
             if (inTransaction > 0) {
                 throw new IllegalStateException("This Hub is already in a transaction");
             }
@@ -115,12 +123,15 @@ public class HubImpl implements Hub {
             inTransaction++;
             
             return completedListeners;
+        } finally {
+            lock.unlock();
         }
     }
     
     /* package */ void activateCurrentDatabase(WriteableBeanDatabaseImpl writeableDatabase, Object commitMessage, List<Change> changes,
             LinkedList<BeanDatabaseUpdateListener> completedListeners) {
-        synchronized (lock) {
+        lock.lock();
+        try {
             inTransaction--;
             if (inTransaction < 0) inTransaction = 0;
             
@@ -149,12 +160,15 @@ public class HubImpl implements Hub {
             }
             
             if (commitError != null) throw commitError;
+        } finally {
+            lock.unlock();
         }
     }
     
     /* package */ void rollbackCurrentDatabase(WriteableBeanDatabaseImpl writeableDatabase, Object commitMessage, List<Change> changes,
             LinkedList<BeanDatabaseUpdateListener> completedListeners) {
-        synchronized (lock) {
+        lock.lock();
+        try {
             inTransaction--;
             if (inTransaction < 0) inTransaction = 0;
             
@@ -179,6 +193,8 @@ public class HubImpl implements Hub {
             }
             
             if (rollbackError != null) throw rollbackError;
+        } finally {
+            lock.unlock();
         }
     }
     

--- a/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/InstanceImpl.java
+++ b/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/InstanceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,6 +16,7 @@
 
 package org.glassfish.hk2.configuration.hub.internal;
 
+import java.util.concurrent.locks.ReentrantLock;
 import org.glassfish.hk2.configuration.hub.api.Instance;
 
 /**
@@ -23,6 +24,7 @@ import org.glassfish.hk2.configuration.hub.api.Instance;
  *
  */
 public class InstanceImpl implements Instance {
+    private final ReentrantLock lock = new ReentrantLock();
     private final Object bean;
     private Object metadata;
     
@@ -43,8 +45,13 @@ public class InstanceImpl implements Instance {
      * @see org.glassfish.hk2.configuration.hub.api.Instance#getMetadata()
      */
     @Override
-    public synchronized Object getMetadata() {
-        return metadata;
+    public Object getMetadata() {
+        lock.lock();
+        try {
+            return metadata;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)

--- a/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/TypeImpl.java
+++ b/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/TypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,7 @@ package org.glassfish.hk2.configuration.hub.internal;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.configuration.hub.api.Instance;
 import org.glassfish.hk2.configuration.hub.api.Type;
@@ -28,6 +29,7 @@ import org.glassfish.hk2.utilities.reflection.ClassReflectionHelper;
  *
  */
 public class TypeImpl implements Type {
+    private final ReentrantLock lock = new ReentrantLock();
     private final String name;
     private final Map<String, Instance> instances;
     private final ClassReflectionHelper helper;
@@ -74,17 +76,26 @@ public class TypeImpl implements Type {
      * @see org.glassfish.hk2.configuration.hub.api.Type#getMetadata()
      */
     @Override
-    public synchronized Object getMetadata() {
-        return metadata;
+    public Object getMetadata() {
+        lock.lock();
+        try {
+            return metadata;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.configuration.hub.api.Type#setMetadata(java.lang.Object)
      */
     @Override
-    public synchronized void setMetadata(Object metadata) {
-        this.metadata = metadata;
-        
+    public void setMetadata(Object metadata) {
+        lock.lock();
+        try {
+            this.metadata = metadata;
+        } finally {
+            lock.unlock();
+        }
     }
     
     @Override

--- a/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/WriteableBeanDatabaseImpl.java
+++ b/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/WriteableBeanDatabaseImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.api.MultiException;
 import org.glassfish.hk2.api.TwoPhaseResource;
@@ -43,7 +44,8 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
     private final HashMap<String, WriteableTypeImpl> types = new HashMap<String, WriteableTypeImpl>();
     private final HubImpl hub;
     private final TwoPhaseResourceImpl resource = new TwoPhaseResourceImpl();
-    
+
+    private final ReentrantLock lock = new ReentrantLock();
     private final LinkedList<Change> changes = new LinkedList<Change>();
     private final LinkedList<WriteableTypeImpl> removedTypes = new LinkedList<WriteableTypeImpl>();
     private boolean committed = false;
@@ -63,8 +65,13 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
      * @see org.glassfish.hk2.configuration.hub.api.BeanDatabase#getAllTypes()
      */
     @Override
-    public synchronized Set<Type> getAllTypes() {
-        return Collections.unmodifiableSet(new HashSet<Type>(types.values()));
+    public Set<Type> getAllTypes() {
+        lock.lock();
+        try {
+            return Collections.unmodifiableSet(new HashSet<Type>(types.values()));
+        } finally {
+            lock.unlock();
+        }
     }
     
     /* (non-Javadoc)
@@ -79,19 +86,29 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
      * @see org.glassfish.hk2.configuration.hub.api.BeanDatabase#getType(java.lang.String)
      */
     @Override
-    public synchronized Type getType(String type) {
-        return types.get(type);
+    public Type getType(String type) {
+        lock.lock();
+        try {
+            return types.get(type);
+        } finally {
+            lock.unlock();
+        }
     }
     
     /* (non-Javadoc)
      * @see org.glassfish.hk2.configuration.hub.api.BeanDatabase#getInstance(java.lang.String, java.lang.Object)
      */
     @Override
-    public synchronized Instance getInstance(String type, String instanceKey) {
-        Type t = getType(type);
-        if (t == null) return null;
-        
-        return t.getInstance(instanceKey);
+    public Instance getInstance(String type, String instanceKey) {
+        lock.lock();
+        try {
+            Type t = getType(type);
+            if (t == null) return null;
+
+            return t.getInstance(instanceKey);
+        } finally {
+            lock.unlock();
+        }
     }
     
     private void checkState() {
@@ -102,75 +119,95 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
      * @see org.glassfish.hk2.configuration.hub.api.WriteableBeanDatabase#addType(java.lang.String)
      */
     @Override
-    public synchronized WriteableType addType(String typeName) {
-        if (typeName == null) throw new IllegalArgumentException();
-        checkState();
-        
-        WriteableTypeImpl wti = new WriteableTypeImpl(this, typeName);
-        
-        changes.add(new ChangeImpl(Change.ChangeCategory.ADD_TYPE,
-                                   wti,
-                                   null,
-                                   null,
-                                   null,
-                                   null));
-        
-        types.put(typeName, wti);
-        
-        return wti;
+    public WriteableType addType(String typeName) {
+        lock.lock();
+        try {
+            if (typeName == null) throw new IllegalArgumentException();
+            checkState();
+
+            WriteableTypeImpl wti = new WriteableTypeImpl(this, typeName);
+
+            changes.add(new ChangeImpl(Change.ChangeCategory.ADD_TYPE,
+                    wti,
+                    null,
+                    null,
+                    null,
+                    null));
+
+            types.put(typeName, wti);
+
+            return wti;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.configuration.hub.api.WriteableBeanDatabase#removeType(java.lang.String)
      */
     @Override
-    public synchronized Type removeType(String typeName) {
-        if (typeName == null) throw new IllegalArgumentException();
-        checkState();
-        
-        WriteableTypeImpl retVal = types.remove(typeName);
-        if (retVal == null) return null;
-        
-        Map<String, Instance> instances = retVal.getInstances();
-        for (String key : new HashSet<String>(instances.keySet())) {
-            retVal.removeInstance(key);
+    public Type removeType(String typeName) {
+        lock.lock();
+        try {
+            if (typeName == null) throw new IllegalArgumentException();
+            checkState();
+
+            WriteableTypeImpl retVal = types.remove(typeName);
+            if (retVal == null) return null;
+
+            Map<String, Instance> instances = retVal.getInstances();
+            for (String key : new HashSet<String>(instances.keySet())) {
+                retVal.removeInstance(key);
+            }
+
+            changes.add(new ChangeImpl(Change.ChangeCategory.REMOVE_TYPE,
+                    retVal,
+                    null,
+                    null,
+                    null,
+                    null));
+
+            removedTypes.add(retVal);
+
+            return retVal;
+        } finally {
+            lock.unlock();
         }
-        
-        changes.add(new ChangeImpl(Change.ChangeCategory.REMOVE_TYPE,
-                retVal,
-                null,
-                null,
-                null,
-                null));
-        
-        removedTypes.add(retVal);
-        
-        return retVal;
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.configuration.hub.api.WriteableBeanDatabase#getWriteableType(java.lang.String)
      */
     @Override
-    public synchronized WriteableType getWriteableType(String typeName) {
-        checkState();
-        return types.get(typeName);
+    public WriteableType getWriteableType(String typeName) {
+        lock.lock();
+        try {
+            checkState();
+            return types.get(typeName);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.configuration.hub.api.WriteableBeanDatabase#findOrAddWriteableType(java.lang.String)
      */
     @Override
-    public synchronized WriteableType findOrAddWriteableType(String typeName) {
-        if (typeName == null) throw new IllegalArgumentException();
-        checkState();
-        
-        WriteableTypeImpl wti = types.get(typeName);
-        if (wti == null) {
-            return addType(typeName);
+    public WriteableType findOrAddWriteableType(String typeName) {
+        lock.lock();
+        try {
+            if (typeName == null) throw new IllegalArgumentException();
+            checkState();
+
+            WriteableTypeImpl wti = types.get(typeName);
+            if (wti == null) {
+                return addType(typeName);
+            }
+
+            return wti;
+        } finally {
+            lock.unlock();
         }
-        
-        return wti;
     }
     
     /* (non-Javadoc)
@@ -179,8 +216,11 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
     @Override
     public void commit() {
         Object defaultCommit;
-        synchronized (this) {
+        lock.lock();
+        try {
             defaultCommit = commitMessage;
+        } finally {
+            lock.unlock();
         }
         
         commit(defaultCommit);
@@ -191,10 +231,13 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
      */
     @Override
     public void commit(Object commitMessage) {
-        synchronized (this) {
+        lock.lock();
+        try {
             checkState();
         
             committed = true;
+        } finally {
+            lock.unlock();
         }
         
         // Outside of lock
@@ -211,8 +254,14 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
         return baseRevision;
     }
     
-    /* package */ synchronized void addChange(Change change) {
-        changes.add(change);
+    /* package */ void addChange(Change change) {
+        lock.lock();
+        try {
+            changes.add(change);
+        } finally {
+            lock.unlock();
+        }
+        
     }
 
     /* (non-Javadoc)
@@ -227,8 +276,13 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
      * @see org.glassfish.hk2.configuration.hub.api.BeanDatabase#dumpDatabase(java.io.PrintStream)
      */
     @Override
-    public synchronized void dumpDatabase(PrintStream output) {
-        Utilities.dumpDatabase(this, output);        
+    public void dumpDatabase(PrintStream output) {
+        lock.lock();
+        try {
+            Utilities.dumpDatabase(this, output);
+        } finally {
+            lock.unlock();
+        }
     }
     
     /* (non-Javadoc)
@@ -251,16 +305,26 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
      * @see org.glassfish.hk2.configuration.hub.api.WriteableBeanDatabase#getCommitMessage()
      */
     @Override
-    public synchronized Object getCommitMessage() {
-        return commitMessage;
+    public Object getCommitMessage() {
+        lock.lock();
+        try {
+            return commitMessage;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.configuration.hub.api.WriteableBeanDatabase#setCommitMessage(java.lang.Object)
      */
     @Override
-    public synchronized void setCommitMessage(Object commitMessage) {
-        this.commitMessage = commitMessage;
+    public void setCommitMessage(Object commitMessage) {
+        lock.lock();
+        try {
+            this.commitMessage = commitMessage;
+        } finally {
+            lock.unlock();
+        }
     }
 
     
@@ -276,12 +340,15 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
                 TwoPhaseTransactionData dynamicConfiguration)
                 throws MultiException {
             Object defaultCommit;
-            synchronized (WriteableBeanDatabaseImpl.this) {
+            WriteableBeanDatabaseImpl.this.lock.lock();
+            try {
                 checkState();
                 
                 committed = true;
                 
                 defaultCommit = commitMessage;
+            } finally {
+                WriteableBeanDatabaseImpl.this.lock.unlock();
             }
             
             // Outside of lock
@@ -298,8 +365,11 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
             this.completedListeners = null;
             
             Object defaultCommit;
-            synchronized (WriteableBeanDatabaseImpl.this) {
+            WriteableBeanDatabaseImpl.this.lock.lock();
+            try {
                 defaultCommit = commitMessage;
+            } finally {
+                WriteableBeanDatabaseImpl.this.lock.unlock();
             }
             
             hub.activateCurrentDatabase(WriteableBeanDatabaseImpl.this, defaultCommit, changes, completedListeners);
@@ -322,8 +392,11 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
             this.completedListeners = null;
             
             Object defaultCommit;
-            synchronized (WriteableBeanDatabaseImpl.this) {
+            WriteableBeanDatabaseImpl.this.lock.lock();
+            try {
                 defaultCommit = commitMessage;
+            } finally {
+                WriteableBeanDatabaseImpl.this.lock.unlock();
             }
             
             hub.rollbackCurrentDatabase(WriteableBeanDatabaseImpl.this, defaultCommit, changes, completedListeners);

--- a/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/WriteableTypeImpl.java
+++ b/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/WriteableTypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.configuration.hub.api.Change;
 import org.glassfish.hk2.configuration.hub.api.Instance;
@@ -34,6 +35,7 @@ import org.glassfish.hk2.utilities.reflection.internal.ClassReflectionHelperImpl
  *
  */
 public class WriteableTypeImpl implements WriteableType {
+    private final ReentrantLock lock = new ReentrantLock();
     private final WriteableBeanDatabaseImpl parent;
     private final String name;
     private final HashMap<String, Instance> beanMap = new HashMap<String, Instance>();
@@ -66,101 +68,131 @@ public class WriteableTypeImpl implements WriteableType {
      * @see org.glassfish.hk2.configuration.hub.api.Type#getInstances()
      */
     @Override
-    public synchronized Map<String, Instance> getInstances() {
-        return Collections.unmodifiableMap(beanMap);
+    public Map<String, Instance> getInstances() {
+        lock.lock();
+        try {
+            return Collections.unmodifiableMap(beanMap);
+        } finally {
+            lock.unlock();
+        }
     }
     
     /* (non-Javadoc)
      * @see org.glassfish.hk2.configuration.hub.api.Type#getInstance(java.lang.Object)
      */
     @Override
-    public synchronized Instance getInstance(String key) {
-        return beanMap.get(key);
+    public Instance getInstance(String key) {
+        lock.lock();
+        try {
+            return beanMap.get(key);
+        } finally {
+            lock.unlock();
+        }
     }
     
     /* (non-Javadoc)
      * @see org.glassfish.hk2.configuration.hub.api.WriteableType#addInstance(java.lang.Object, java.lang.Object)
      */
     @Override
-    public synchronized Instance addInstance(String key, Object bean) {
-        return addInstance(key, bean, null);
+    public Instance addInstance(String key, Object bean) {
+        lock.lock();
+        try {
+            return addInstance(key, bean, null);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.configuration.hub.api.WriteableType#addInstance(java.lang.Object, java.lang.Object)
      */
     @Override
-    public synchronized Instance addInstance(String key, Object bean, Object metadata) {
-        if (key == null || bean == null) throw new IllegalArgumentException();
-        
-        InstanceImpl ii = new InstanceImpl(bean, metadata);
-        
-        parent.addChange(new ChangeImpl(Change.ChangeCategory.ADD_INSTANCE,
-                                   this,
-                                   key,
-                                   ii,
-                                   null,
-                                   null));
-        
-        beanMap.put(key, ii);
-        
-        return ii;
+    public Instance addInstance(String key, Object bean, Object metadata) {
+        lock.lock();
+        try {
+            if (key == null || bean == null) throw new IllegalArgumentException();
+
+            InstanceImpl ii = new InstanceImpl(bean, metadata);
+
+            parent.addChange(new ChangeImpl(Change.ChangeCategory.ADD_INSTANCE,
+                    this,
+                    key,
+                    ii,
+                    null,
+                    null));
+
+            beanMap.put(key, ii);
+
+            return ii;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.configuration.hub.api.WriteableType#removeInstance(java.lang.Object)
      */
     @Override
-    public synchronized Instance removeInstance(String key) {
-        if (key == null) throw new IllegalArgumentException();
-        
-        Instance removedValue = beanMap.remove(key);
-        if (removedValue == null) return null;
-        
-        parent.addChange(new ChangeImpl(Change.ChangeCategory.REMOVE_INSTANCE,
-                this,
-                key,
-                removedValue,
-                null,
-                null));
-        
-        return removedValue;
+    public Instance removeInstance(String key) {
+        lock.lock();
+        try {
+            if (key == null) throw new IllegalArgumentException();
+            
+            Instance removedValue = beanMap.remove(key);
+            if (removedValue == null) return null;
+            
+            parent.addChange(new ChangeImpl(Change.ChangeCategory.REMOVE_INSTANCE,
+                    this,
+                    key,
+                    removedValue,
+                    null,
+                    null));
+            
+            return removedValue;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.configuration.hub.api.WriteableType#modifyInstance(java.lang.Object, java.lang.Object, java.beans.PropertyChangeEvent[])
      */
     @Override
-    public synchronized PropertyChangeEvent[] modifyInstance(String key, Object newBean,
+    public PropertyChangeEvent[] modifyInstance(String key, Object newBean,
             PropertyChangeEvent... propChanges) {
-        if (key == null || newBean == null) throw new IllegalArgumentException();
-        
-        Instance oldInstance = beanMap.get(key);
-        if (oldInstance == null) {
-            throw new IllegalStateException("Attempting to modify bean with key " + key + " but no such bean exists");
-        }
-        
-        InstanceImpl newInstance = new InstanceImpl(newBean, oldInstance.getMetadata());
-        
-        if (propChanges.length == 0) {
-            propChanges = BeanReflectionHelper.getChangeEvents(helper, oldInstance.getBean(), newInstance.getBean());
-        }
-        
-        beanMap.put(key, newInstance);
+        lock.lock();
+        try {
+            if (key == null || newBean == null) throw new IllegalArgumentException();
 
-        ArrayList<PropertyChangeEvent> propChangesList = new ArrayList<PropertyChangeEvent>(propChanges.length);
-        for (PropertyChangeEvent pce : propChanges) {
-            propChangesList.add(pce);
+            Instance oldInstance = beanMap.get(key);
+            if (oldInstance == null) {
+                throw new IllegalStateException("Attempting to modify bean with key " + key + " but no such bean exists");
+            }
+
+            InstanceImpl newInstance = new InstanceImpl(newBean, oldInstance.getMetadata());
+
+            if (propChanges.length == 0) {
+                propChanges = BeanReflectionHelper.getChangeEvents(helper, oldInstance.getBean(), newInstance.getBean());
+            }
+
+            beanMap.put(key, newInstance);
+
+            ArrayList<PropertyChangeEvent> propChangesList = new ArrayList<PropertyChangeEvent>(propChanges.length);
+            for (PropertyChangeEvent pce : propChanges) {
+                propChangesList.add(pce);
+            }
+
+            parent.addChange(new ChangeImpl(Change.ChangeCategory.MODIFY_INSTANCE,
+                    this,
+                    key,
+                    newInstance,
+                    oldInstance,
+                    propChangesList));
+
+            return propChanges;
+        } finally {
+            lock.unlock();
         }
-        
-        parent.addChange(new ChangeImpl(Change.ChangeCategory.MODIFY_INSTANCE,
-                this,
-                key,
-                newInstance,
-                oldInstance,
-                propChangesList));
-        
-        return propChanges;
     }
 
     ClassReflectionHelper getHelper() {
@@ -171,16 +203,26 @@ public class WriteableTypeImpl implements WriteableType {
      * @see org.glassfish.hk2.configuration.hub.api.Type#getMetadata()
      */
     @Override
-    public synchronized Object getMetadata() {
-        return metadata;
+    public Object getMetadata() {
+        lock.lock();
+        try {
+            return metadata;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.configuration.hub.api.Type#setMetadata(java.lang.Object)
      */
     @Override
-    public synchronized void setMetadata(Object metadata) {
-        this.metadata = metadata;
+    public void setMetadata(Object metadata) {
+        lock.lock();
+        try {
+            this.metadata = metadata;
+        } finally {
+            lock.unlock();
+        }
     }
     
     @Override

--- a/hk2-configuration/manager/src/test/java/org/glassfish/hk2/configuration/hub/test/AbstractCountingListener.java
+++ b/hk2-configuration/manager/src/test/java/org/glassfish/hk2/configuration/hub/test/AbstractCountingListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,6 +17,7 @@
 package org.glassfish.hk2.configuration.hub.test;
 
 import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Singleton;
 
@@ -30,20 +31,36 @@ import org.glassfish.hk2.configuration.hub.api.Change;
  */
 @Singleton
 public class AbstractCountingListener implements BeanDatabaseUpdateListener {
+    private final ReentrantLock lock = new ReentrantLock();
     private int prepareCalled;
     private int rollbackCalled;
     private int commitCalled;
     
-    public synchronized int getNumPreparesCalled() {
-        return prepareCalled;
+    public int getNumPreparesCalled() {
+        lock.lock();
+        try {
+            return prepareCalled;
+        } finally {
+            lock.unlock();
+        }
     }
     
-    public synchronized int getNumCommitsCalled() {
-        return commitCalled;
+    public int getNumCommitsCalled() {
+        lock.lock();
+        try {
+            return commitCalled;
+        } finally {
+            lock.unlock();
+        }
     }
     
-    public synchronized int getNumRollbackCalled() {
-        return rollbackCalled;
+    public int getNumRollbackCalled() {
+        lock.lock();
+        try {
+            return rollbackCalled;
+        } finally {
+            lock.unlock();
+        }
     }
     
     public void prepareAction() {
@@ -59,11 +76,16 @@ public class AbstractCountingListener implements BeanDatabaseUpdateListener {
      * @see org.glassfish.hk2.configuration.hub.api.BeanDatabaseUpdateListener#prepareDatabaseChange(org.glassfish.hk2.configuration.hub.api.BeanDatabase, org.glassfish.hk2.configuration.hub.api.BeanDatabase, java.lang.Object, java.util.List)
      */
     @Override
-    public synchronized void prepareDatabaseChange(BeanDatabase currentDatabase,
+    public void prepareDatabaseChange(BeanDatabase currentDatabase,
             BeanDatabase proposedDatabase, Object commitMessage,
             List<Change> changes) {
-        prepareCalled++;
-        prepareAction();
+        lock.lock();
+        try {
+            prepareCalled++;
+            prepareAction();
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/ChildDataModel.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/ChildDataModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,6 +19,7 @@ package org.glassfish.hk2.xml.internal;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.utilities.general.GeneralUtilities;
 
@@ -43,8 +44,8 @@ public class ChildDataModel implements Serializable {
         TYPE_MAP.put("double", double.class);
         TYPE_MAP.put("boolean", boolean.class);
     };
-    
-    private final Object lock = new Object();
+
+    private final ReentrantLock lock = new ReentrantLock();
     
     /** Set at compile time, the type of the thing */
     private String childType;
@@ -113,13 +114,17 @@ public class ChildDataModel implements Serializable {
     }
     
     public void setLoader(ClassLoader myLoader) {
-        synchronized (lock) {
+        lock.lock();
+        try {
             this.myLoader = myLoader;
+        } finally  {
+            lock.unlock();
         }
     }
     
     public Class<?> getChildTypeAsClass() {
-        synchronized (lock) {
+        lock.lock();
+        try {
             if (childTypeAsClass != null) return childTypeAsClass;
             
             childTypeAsClass = TYPE_MAP.get(childType);
@@ -128,12 +133,15 @@ public class ChildDataModel implements Serializable {
             childTypeAsClass = GeneralUtilities.loadClass(myLoader, childType);
             
             return childTypeAsClass;
+        } finally {
+            lock.unlock();
         }
         
     }
     
     public Class<?> getChildListTypeAsClass() {
-        synchronized (lock) {
+        lock.lock();
+        try {
             if (childListType == null) return null;
             if (childListTypeAsClass != null) return childListTypeAsClass;
             
@@ -143,6 +151,8 @@ public class ChildDataModel implements Serializable {
             childListTypeAsClass = GeneralUtilities.loadClass(myLoader, childListType);
             
             return childListTypeAsClass;
+        } finally {
+            lock.unlock();
         }
         
     }

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/JAUtilities.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/JAUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javassist.ClassPool;
 import javassist.CtClass;
@@ -74,7 +75,8 @@ public class JAUtilities {
     public final static String REMOVE = "remove";
     public final static String JAXB_DEFAULT_STRING = "##default";
     public final static String JAXB_DEFAULT_DEFAULT = "\u0000";
-    
+
+    private final ReentrantLock lock = new ReentrantLock();
     private final ClassReflectionHelper classReflectionHelper;
     private final ClassPool defaultClassPool;
     private final CtClass superClazz;
@@ -143,38 +145,43 @@ public class JAUtilities {
         return entry.getValue();
     }
     
-    public synchronized void convertRootAndLeaves(Class<?> root, boolean mustConvertAll) {
-        long currentTime = 0L;
-        if (DEBUG_GENERATION_TIMING) {
-            computer.numGenerated = 0;
-            computer.numPreGenerated = 0;
-            
-            currentTime = System.currentTimeMillis();
-        }
-        
-        ModelImpl rootModel = interface2ModelCache.compute(root).getValue();
-        if (!mustConvertAll) {
+    public void convertRootAndLeaves(Class<?> root, boolean mustConvertAll) {
+        lock.lock();
+        try {
+            long currentTime = 0L;
+            if (DEBUG_GENERATION_TIMING) {
+                computer.numGenerated = 0;
+                computer.numPreGenerated = 0;
+
+                currentTime = System.currentTimeMillis();
+            }
+
+            ModelImpl rootModel = interface2ModelCache.compute(root).getValue();
+            if (!mustConvertAll) {
+                if (DEBUG_GENERATION_TIMING) {
+                    currentTime = System.currentTimeMillis() - currentTime;
+
+                    Logger.getLogger().debug("Took " + currentTime + " to perform " +
+                            computer.numGenerated + " generations with " +
+                            computer.numPreGenerated + " pre generated with a lazy parser");
+                }
+                return;
+            }
+
+            HashSet<Class<?>> cycles = new HashSet<Class<?>>();
+            cycles.add(root);
+
+            convertAllRootAndLeaves(rootModel, cycles);
+
             if (DEBUG_GENERATION_TIMING) {
                 currentTime = System.currentTimeMillis() - currentTime;
-                
-                Logger.getLogger().debug("Took " + currentTime + " to perform " +
-                  computer.numGenerated + " generations with " +
-                  computer.numPreGenerated + " pre generated with a lazy parser");
+
+                Logger.getLogger().debug("Took " + currentTime + " milliseconds to perform " +
+                        computer.numGenerated + " generations with " +
+                        computer.numPreGenerated + " pre generated with a non-lazy parser");
             }
-            return;
-        }
-        
-        HashSet<Class<?>> cycles = new HashSet<Class<?>>();
-        cycles.add(root);
-        
-        convertAllRootAndLeaves(rootModel, cycles);
-        
-        if (DEBUG_GENERATION_TIMING) {
-            currentTime = System.currentTimeMillis() - currentTime;
-            
-            Logger.getLogger().debug("Took " + currentTime + " milliseconds to perform " +
-              computer.numGenerated + " generations with " +
-              computer.numPreGenerated + " pre generated with a non-lazy parser");
+        } finally {
+            lock.unlock();
         }
     }
     

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/ModelImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/ModelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,6 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
@@ -49,7 +50,8 @@ public class ModelImpl implements Model {
     private static final long serialVersionUID = 752816761552710497L;
     
     /** For thread safety on the computed fields */
-    private final static Object lock = new Object();
+    private final ReentrantLock lock = new ReentrantLock();
+    private final static ReentrantLock slock = new ReentrantLock();
 
     /** The interface from which the JAXB proxy was created, fully qualified */
     private String originalInterface;
@@ -261,7 +263,8 @@ public class ModelImpl implements Model {
     }
     
     public Set<String> getAllXmlWrappers() {
-        synchronized (lock) {
+        slock.lock();
+        try {
             if (allXmlWrappers != null) return allXmlWrappers;
             allXmlWrappers = new LinkedHashSet<String>();
             
@@ -272,6 +275,8 @@ public class ModelImpl implements Model {
             }
             
             return allXmlWrappers;
+        } finally {
+            slock.unlock();
         }
     }
     
@@ -280,7 +285,8 @@ public class ModelImpl implements Model {
     }
     
     public Set<QName> getUnKeyedChildren() {
-        synchronized (lock) {
+        slock.lock();
+        try {
             if (unKeyedChildren != null) return unKeyedChildren;
             
             unKeyedChildren = new HashSet<QName>();
@@ -291,11 +297,14 @@ public class ModelImpl implements Model {
             }
             
             return unKeyedChildren;
+        } finally {
+            slock.unlock();
         }
     }
     
     public Set<QName> getKeyedChildren() {
-        synchronized (lock) {
+        slock.lock();
+        try {
             if (keyedChildren != null) return keyedChildren;
             
             keyedChildren = new HashSet<QName>();
@@ -306,11 +315,14 @@ public class ModelImpl implements Model {
             }
             
             return keyedChildren;
+        } finally {
+            slock.unlock();
         }
     }
     
     public void setJAUtilities(JAUtilities jaUtilities, ClassLoader myLoader) {
-        synchronized (lock) {
+        slock.lock();
+        try {
             if (this.jaUtilities != null) return;
             this.jaUtilities = jaUtilities;
             this.myLoader = myLoader;
@@ -322,46 +334,60 @@ public class ModelImpl implements Model {
             for (ChildDataModel cdm : nonChildProperty.values()) {
                 cdm.setLoader(myLoader);
             }
+        } finally {
+            slock.unlock();
         }
     }
     
     public String getDefaultChildValue(String propNamespace, String propName) {
         QName propQName = QNameUtilities.createQName(propNamespace, propName);
         
-        synchronized (lock) {
+        slock.lock();
+        try {
             ChildDataModel cd = nonChildProperty.get(propQName);
             if (cd == null) return null;
             return cd.getDefaultAsString();
+        } finally {
+            slock.unlock();
         }
     }
     
     public ModelPropertyType getModelPropertyType(String propNamespace, String propName) {
         QName propQName = QNameUtilities.createQName(propNamespace, propName);
         
-        synchronized (lock) {
+        slock.lock();
+        try {
             if (nonChildProperty.containsKey(propQName)) return ModelPropertyType.FLAT_PROPERTY;
             if (childrenByName.containsKey(propQName)) return ModelPropertyType.TREE_ROOT;
             
             return ModelPropertyType.UNKNOWN;
+        }  finally {
+            slock.unlock();
         }
     }
     
     public Class<?> getNonChildType(String propNamespace, String propName) {
         QName propQName = QNameUtilities.createQName(propNamespace, propName);
         
-        synchronized (lock) {
+        slock.lock();
+        try {
             ChildDataModel cd = nonChildProperty.get(propQName);
             if (cd == null) return null;
             
             return cd.getChildTypeAsClass();
+        } finally {
+            slock.unlock();
         }
     }
     
     public ParentedModel getChild(String propNamespace, String propName) {
         QName propQName = QNameUtilities.createQName(propNamespace, propName);
         
-        synchronized (lock) {
+        slock.lock();
+        try {
             return childrenByName.get(propQName);
+        } finally {
+            slock.unlock();
         }
     }
     
@@ -369,12 +395,15 @@ public class ModelImpl implements Model {
     public Class<?> getOriginalInterfaceAsClass() {
         if (originalInterfaceAsClass != null) return originalInterfaceAsClass;
         
-        synchronized (lock) {
+        slock.lock();
+        try {
             if (originalInterfaceAsClass != null) return originalInterfaceAsClass;
             
             originalInterfaceAsClass = GeneralUtilities.loadClass(myLoader, originalInterface);
             return originalInterfaceAsClass;
             
+        } finally {
+            slock.unlock();
         }
     }
     
@@ -382,24 +411,33 @@ public class ModelImpl implements Model {
     public Class<?> getProxyAsClass() {
         if (translatedClassAsClass != null) return translatedClassAsClass;
         
-        synchronized (lock) {
+        slock.lock();
+        try {
             if (translatedClassAsClass != null) return translatedClassAsClass;
             
             translatedClassAsClass = GeneralUtilities.loadClass(myLoader, translatedClass);
             return translatedClassAsClass;
             
+        } finally {
+            slock.unlock();
         }
     }
     
     public Collection<ParentedModel> getAllChildren() {
-        synchronized (lock) {
+        slock.lock();
+        try {
             return Collections.unmodifiableCollection(childrenByName.values());
+        } finally {
+            slock.unlock();
         }
     }
     
     public Map<QName, ParentedModel> getChildrenProperties() {
-        synchronized (lock) {
+        slock.lock();
+        try {
             return Collections.unmodifiableMap(childrenByName);
+        } finally {
+            slock.unlock();
         }
     }
     
@@ -441,52 +479,55 @@ public class ModelImpl implements Model {
         return retVal;
     }
     
-    public synchronized String getJavaNameFromKey(String key, ClassReflectionHelper reflectionHelper) {
-        if (keyToJavaNameMap == null) {
-            keyToJavaNameMap = new LinkedHashMap<String, String>();
+    public String getJavaNameFromKey(String key, ClassReflectionHelper reflectionHelper) {
+        lock.lock();
+        try {
+            if (keyToJavaNameMap == null) {
+                keyToJavaNameMap = new LinkedHashMap<String, String>();
+            }
+
+            String result = keyToJavaNameMap.get(key);
+            if (result != null) return result;
+
+            if (reflectionHelper == null) return null;
+
+            Class<?> originalInterface = getOriginalInterfaceAsClass();
+
+            for (MethodWrapper wrapper : reflectionHelper.getAllMethods(originalInterface)) {
+                Method m = wrapper.getMethod();
+
+                String xmlName;
+
+                XmlElement element = m.getAnnotation(XmlElement.class);
+                if (element == null) {
+                    XmlAttribute attribute = m.getAnnotation(XmlAttribute.class);
+                    if (attribute == null) continue;
+
+                    xmlName = attribute.name();
+                } else {
+                    xmlName = element.name();
+                }
+
+                String keyName;
+                String javaName = getJavaNameFromGetterOrSetter(m, reflectionHelper);
+
+                if ("##default".equals(xmlName)) {
+                    keyName = javaName;
+                } else {
+                    keyName = xmlName;
+                }
+
+                if (!key.equals(keyName)) continue;
+
+                // Found it!
+                keyToJavaNameMap.put(key, javaName);
+                return javaName;
+            }
+
+            return null;
+        } finally {
+            lock.unlock();
         }
-        
-        String result = keyToJavaNameMap.get(key);
-        if (result != null) return result;
-        
-        if (reflectionHelper == null) return null;
-        
-        Class<?> originalInterface = getOriginalInterfaceAsClass();
-        
-        for (MethodWrapper wrapper : reflectionHelper.getAllMethods(originalInterface)) {
-            Method m = wrapper.getMethod();
-            
-            String xmlName;
-            
-            XmlElement element = m.getAnnotation(XmlElement.class);
-            if (element == null) {
-                XmlAttribute attribute = m.getAnnotation(XmlAttribute.class);
-                if (attribute == null) continue;
-                
-                xmlName = attribute.name();
-            }
-            else {
-                xmlName =  element.name();
-            }
-            
-            String keyName;
-            String javaName = getJavaNameFromGetterOrSetter(m, reflectionHelper);
-            
-            if ("##default".equals(xmlName)) {
-                keyName = javaName;
-            }
-            else {
-                keyName = xmlName;
-            }
-            
-            if (!key.equals(keyName)) continue;
-            
-            // Found it!
-            keyToJavaNameMap.put(key, javaName);
-            return javaName;
-        }
-        
-        return null;
     }
     
     private static String getJavaNameFromGetterOrSetter(Method m, ClassReflectionHelper reflectionHelper) {

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/ParentedModel.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/ParentedModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,6 +17,7 @@
 package org.glassfish.hk2.xml.internal;
 
 import java.io.Serializable;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
@@ -34,8 +35,8 @@ import org.glassfish.hk2.utilities.general.GeneralUtilities;
  */
 public class ParentedModel implements Serializable {
     private static final long serialVersionUID = -2480798409414987937L;
-    
-    private final Object lock = new Object();
+
+    private final ReentrantLock lock = new ReentrantLock();
     
     /** The interface of the child for which this is a parent */
     private String childInterface;
@@ -126,7 +127,8 @@ public class ParentedModel implements Serializable {
     
     @SuppressWarnings("unchecked")
     public XmlAdapter<?, ?> getAdapterObject() {
-        synchronized (lock) {
+        lock.lock();
+        try {
             if (myLoader == null) {
                 throw new IllegalStateException("Cannot call getChildModel before the classloader has been determined");
             }
@@ -149,12 +151,15 @@ public class ParentedModel implements Serializable {
             catch (Exception e) {
                 throw new RuntimeException(e);
             }
+        } finally {
+            lock.unlock();
         }
         
     }
     
     public ModelImpl getChildModel() {
-        synchronized (lock) {
+        lock.lock();
+        try {
             if (myLoader == null) {
                 throw new IllegalStateException("Cannot call getChildModel before the classloader has been determined");
             }
@@ -174,13 +179,18 @@ public class ParentedModel implements Serializable {
             }
             
             return childModel;
+        } finally {
+            lock.unlock();
         }
     }
     
     public void setRuntimeInformation(JAUtilities jaUtilities, ClassLoader myLoader) {
-        synchronized (lock) {
+        lock.lock();
+        try {
             this.jaUtilities = jaUtilities;
             this.myLoader = myLoader;
+        } finally {
+            lock.unlock();
         }
     }
     

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/UnkeyedDiff.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/UnkeyedDiff.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.utilities.cache.CacheUtilities;
 import org.glassfish.hk2.utilities.cache.Computable;
@@ -48,7 +49,8 @@ public class UnkeyedDiff {
             return Boolean.getBoolean(UNKEYED_DEBUG_PROPERTY);
         }   
     });
-    
+
+    private final ReentrantLock lock = new ReentrantLock();
     private final List<BaseHK2JAXBBean> legacyList;
     private final List<BaseHK2JAXBBean> proposedList;
     private final ParentedModel parentModel;
@@ -90,22 +92,26 @@ public class UnkeyedDiff {
         this(asList(legacy), asList(proposed), parent, parentModel);
     }
     
-    public synchronized Differences compute() {
-        if (computed) return finalSolution;
-        
-        Differences retVal = null;
+    public Differences compute() {
+        lock.lock();
         try {
-            retVal = internalCompute();
-        }
-        finally {
-            if (retVal != null) {
-                finalSolution = retVal;
-            
-                computed = true;
+            if (computed) return finalSolution;
+
+            Differences retVal = null;
+            try {
+                retVal = internalCompute();
+            } finally {
+                if (retVal != null) {
+                    finalSolution = retVal;
+
+                    computed = true;
+                }
             }
+
+            return retVal;
+        }  finally {
+            lock.unlock();
         }
-        
-        return retVal;
     }
     
     private Differences internalCompute() {

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/clazz/AnnotationAltAnnotationImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/clazz/AnnotationAltAnnotationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.utilities.reflection.ClassReflectionHelper;
 import org.glassfish.hk2.utilities.reflection.ReflectionHelper;
@@ -44,7 +45,8 @@ public class AnnotationAltAnnotationImpl implements AltAnnotation {
         DO_NOT_HANDLE_METHODS.add("toString");
         DO_NOT_HANDLE_METHODS.add("annotationType");
     }
-    
+
+    private final ReentrantLock lock = new ReentrantLock();
     private final Annotation annotation;
     private final ClassReflectionHelper helper;
     private Map<String, Object> values;
@@ -75,33 +77,49 @@ public class AnnotationAltAnnotationImpl implements AltAnnotation {
      * @see org.glassfish.hk2.xml.internal.alt.AltAnnotation#getStringValue(java.lang.String)
      */
     @Override
-    public synchronized String getStringValue(String methodName) {
-        if (values == null) getAnnotationValues();
-        
-        if (XmlElementImpl.class.equals(annotation.getClass()) &&
-                "getTypeByName".equals(methodName)) {
-            XmlElementImpl xei = (XmlElementImpl) annotation;
-            return xei.getTypeByName();
+    public String getStringValue(String methodName) {
+        lock.lock();
+        try {
+            if (values == null) getAnnotationValues();
+
+            if (XmlElementImpl.class.equals(annotation.getClass()) &&
+                    "getTypeByName".equals(methodName)) {
+                XmlElementImpl xei = (XmlElementImpl) annotation;
+                return xei.getTypeByName();
+            }
+
+            return (String) values.get(methodName);
+        } finally {
+            lock.unlock();
         }
-        
-        return (String) values.get(methodName);
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.xml.internal.alt.AltAnnotation#getBooleanValue(java.lang.String)
      */
     @Override
-    public synchronized boolean getBooleanValue(String methodName) {
-        if (values == null) getAnnotationValues();
-        
-        return (Boolean) values.get(methodName);
+    public boolean getBooleanValue(String methodName) {
+        lock.lock();
+        try {
+            if (values == null) getAnnotationValues();
+
+            return (Boolean) values.get(methodName);
+        } finally {
+            lock.unlock();
+        }
     }
     
     @Override
-    public synchronized String[] getStringArrayValue(String methodName) {
-        if (values == null) getAnnotationValues();
-        
-        return (String[]) values.get(methodName);
+    public String[] getStringArrayValue(String methodName) {
+        lock.lock();
+        try {
+
+            if (values == null) getAnnotationValues();
+
+            return (String[]) values.get(methodName);
+        } finally {
+            lock.unlock();
+        }
     }
     
     @Override
@@ -122,76 +140,75 @@ public class AnnotationAltAnnotationImpl implements AltAnnotation {
      * @see org.glassfish.hk2.xml.internal.alt.AltAnnotation#getAnnotationValues()
      */
     @Override
-    public synchronized Map<String, Object> getAnnotationValues() {
-        if (values != null) return values;
-        
-        Map<String, Object> retVal = new TreeMap<String, Object>();
-        for (Method javaAnnotationMethod : annotation.annotationType().getMethods()) {
-            if (javaAnnotationMethod.getParameterTypes().length != 0) continue;
-            if (DO_NOT_HANDLE_METHODS.contains(javaAnnotationMethod.getName())) continue;
-            
-            String key = javaAnnotationMethod.getName();
-            
-            Object value;
-            try {
-                value = ReflectionHelper.invoke(annotation, javaAnnotationMethod, new Object[0], false);
-                
-                if (value == null) {
-                    throw new AssertionError("Recieved null from annotation method " + javaAnnotationMethod.getName());
+    public Map<String, Object> getAnnotationValues() {
+        lock.lock();
+        try {
+            if (values != null) return values;
+
+            Map<String, Object> retVal = new TreeMap<String, Object>();
+            for (Method javaAnnotationMethod : annotation.annotationType().getMethods()) {
+                if (javaAnnotationMethod.getParameterTypes().length != 0) continue;
+                if (DO_NOT_HANDLE_METHODS.contains(javaAnnotationMethod.getName())) continue;
+
+                String key = javaAnnotationMethod.getName();
+
+                Object value;
+                try {
+                    value = ReflectionHelper.invoke(annotation, javaAnnotationMethod, new Object[0], false);
+
+                    if (value == null) {
+                        throw new AssertionError("Recieved null from annotation method " + javaAnnotationMethod.getName());
+                    }
+                } catch (RuntimeException re) {
+                    throw re;
+                } catch (Throwable th) {
+                    throw new RuntimeException(th);
                 }
-            }
-            catch (RuntimeException re) {
-                throw re;
-            }
-            catch (Throwable th) {
-                throw new RuntimeException(th);
-            }
-            
-            if (value instanceof Class) {
-                value = new ClassAltClassImpl((Class<?>) value, helper);
-            }
-            else if (Enum.class.isAssignableFrom(value.getClass())) {
-                value = new EnumAltEnumImpl((Enum<?>) value);
-            }
-            else if (value.getClass().isArray() && Class.class.equals(value.getClass().getComponentType())) {
-                Class<?> cValue[] = (Class<?>[]) value;
-                
-                AltClass[] translatedValue = new AltClass[cValue.length];
-                
-                for (int lcv = 0; lcv < cValue.length; lcv++) {
-                    translatedValue[lcv] = new ClassAltClassImpl(cValue[lcv], helper);
+
+                if (value instanceof Class) {
+                    value = new ClassAltClassImpl((Class<?>) value, helper);
+                } else if (Enum.class.isAssignableFrom(value.getClass())) {
+                    value = new EnumAltEnumImpl((Enum<?>) value);
+                } else if (value.getClass().isArray() && Class.class.equals(value.getClass().getComponentType())) {
+                    Class<?> cValue[] = (Class<?>[]) value;
+
+                    AltClass[] translatedValue = new AltClass[cValue.length];
+
+                    for (int lcv = 0; lcv < cValue.length; lcv++) {
+                        translatedValue[lcv] = new ClassAltClassImpl(cValue[lcv], helper);
+                    }
+
+                    value = translatedValue;
+                } else if (value.getClass().isArray() && Enum.class.isAssignableFrom(value.getClass().getComponentType())) {
+                    Enum<?> eValue[] = (Enum<?>[]) value;
+
+                    AltEnum[] translatedValue = new AltEnum[eValue.length];
+
+                    for (int lcv = 0; lcv < eValue.length; lcv++) {
+                        translatedValue[lcv] = new EnumAltEnumImpl(eValue[lcv]);
+                    }
+
+                    value = translatedValue;
+                } else if (value.getClass().isArray() && Annotation.class.isAssignableFrom(value.getClass().getComponentType())) {
+                    Annotation aValue[] = (Annotation[]) value;
+
+                    AltAnnotation[] translatedValue = new AltAnnotation[aValue.length];
+
+                    for (int lcv = 0; lcv < aValue.length; lcv++) {
+                        translatedValue[lcv] = new AnnotationAltAnnotationImpl(aValue[lcv], helper);
+                    }
+
+                    value = translatedValue;
                 }
-                
-                value = translatedValue;
+
+                retVal.put(key, value);
             }
-            else if (value.getClass().isArray() && Enum.class.isAssignableFrom(value.getClass().getComponentType())) {
-                Enum<?> eValue[] = (Enum<?>[]) value;
-                
-                AltEnum[] translatedValue = new AltEnum[eValue.length];
-                
-                for (int lcv = 0; lcv < eValue.length; lcv++) {
-                    translatedValue[lcv] = new EnumAltEnumImpl(eValue[lcv]);
-                }
-                
-                value = translatedValue;
-            }
-            else if (value.getClass().isArray() && Annotation.class.isAssignableFrom(value.getClass().getComponentType())) {
-                Annotation aValue[] = (Annotation[]) value;
-                
-                AltAnnotation[] translatedValue = new AltAnnotation[aValue.length];
-                
-                for (int lcv = 0; lcv < aValue.length; lcv++) {
-                    translatedValue[lcv] = new AnnotationAltAnnotationImpl(aValue[lcv], helper);
-                }
-                
-                value = translatedValue;
-            }
-            
-            retVal.put(key, value);
+
+            values = Collections.unmodifiableMap(retVal);
+            return values;
+        } finally {
+            lock.unlock();
         }
-        
-        values = Collections.unmodifiableMap(retVal);
-        return values;
     }
     
     @Override

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/clazz/ClassAltClassImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/clazz/ClassAltClassImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
@@ -51,7 +52,8 @@ public class ClassAltClassImpl implements AltClass {
     public static final AltClass DOUBLE = new ClassAltClassImpl(double.class, SCALAR_HELPER);
     public static final AltClass OBJECT = new ClassAltClassImpl(Object.class, SCALAR_HELPER);
     public static final AltClass XML_ADAPTER = new ClassAltClassImpl(XmlAdapter.class, SCALAR_HELPER);
-    
+
+    private final ReentrantLock lock = new ReentrantLock();
     private final Class<?> clazz;
     private final ClassReflectionHelper helper;
     private List<AltMethod> methods;
@@ -86,36 +88,46 @@ public class ClassAltClassImpl implements AltClass {
      * @see org.glassfish.hk2.xml.internal.alt.AltClass#getAnnotations()
      */
     @Override
-    public synchronized List<AltAnnotation> getAnnotations() {
-        if (annotations != null) return annotations;
-        
-        Annotation annotationz[] = clazz.getAnnotations();
-        
-        ArrayList<AltAnnotation> retVal = new ArrayList<AltAnnotation>(annotationz.length);
-        for (Annotation annotation : annotationz) {
-            retVal.add(new AnnotationAltAnnotationImpl(annotation, helper));
+    public List<AltAnnotation> getAnnotations() {
+        lock.lock();
+        try {
+            if (annotations != null) return annotations;
+
+            Annotation annotationz[] = clazz.getAnnotations();
+
+            ArrayList<AltAnnotation> retVal = new ArrayList<AltAnnotation>(annotationz.length);
+            for (Annotation annotation : annotationz) {
+                retVal.add(new AnnotationAltAnnotationImpl(annotation, helper));
+            }
+
+            annotations = Collections.unmodifiableList(retVal);
+            return annotations;
+        } finally {
+            lock.unlock();
         }
-        
-        annotations = Collections.unmodifiableList(retVal);
-        return annotations;
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.xml.internal.alt.AltClass#getMethods()
      */
     @Override
-    public synchronized List<AltMethod> getMethods() {
-        if (methods != null) return methods;
-        
-        Set<MethodWrapper> wrappers = helper.getAllMethods(clazz);
-        ArrayList<AltMethod> retVal = new ArrayList<AltMethod>(wrappers.size());
-        
-        for (MethodWrapper method : wrappers) {
-            retVal.add(new MethodAltMethodImpl(method.getMethod(), helper));
+    public List<AltMethod> getMethods() {
+        lock.lock();
+        try {
+            if (methods != null) return methods;
+
+            Set<MethodWrapper> wrappers = helper.getAllMethods(clazz);
+            ArrayList<AltMethod> retVal = new ArrayList<AltMethod>(wrappers.size());
+
+            for (MethodWrapper method : wrappers) {
+                retVal.add(new MethodAltMethodImpl(method.getMethod(), helper));
+            }
+
+            methods = Collections.unmodifiableList(retVal);
+            return methods;
+        } finally {
+            lock.unlock();
         }
-        
-        methods = Collections.unmodifiableList(retVal);
-        return methods;
     }
     
     @Override

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/clazz/MethodAltMethodImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/clazz/MethodAltMethodImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,7 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.utilities.reflection.ClassReflectionHelper;
 import org.glassfish.hk2.utilities.reflection.ReflectionHelper;
@@ -35,6 +36,7 @@ import org.glassfish.hk2.xml.internal.alt.MethodInformationI;
  *
  */
 public class MethodAltMethodImpl implements AltMethod {
+    private final ReentrantLock lock = new ReentrantLock();
     private final Method method;
     private final ClassReflectionHelper helper;
     private List<AltClass> parameterTypes;
@@ -73,18 +75,23 @@ public class MethodAltMethodImpl implements AltMethod {
      * @see org.glassfish.hk2.xml.internal.alt.AltMethod#getParameterTypes()
      */
     @Override
-    public synchronized List<AltClass> getParameterTypes() {
-        if (parameterTypes != null) return parameterTypes;
-        
-        Class<?> pTypes[] = method.getParameterTypes();
-        List<AltClass> retVal = new ArrayList<AltClass>(pTypes.length);
-        
-        for (Class<?> pType : pTypes) {
-            retVal.add(new ClassAltClassImpl(pType, helper));
+    public List<AltClass> getParameterTypes() {
+        lock.lock();
+        try {
+            if (parameterTypes != null) return parameterTypes;
+
+            Class<?> pTypes[] = method.getParameterTypes();
+            List<AltClass> retVal = new ArrayList<AltClass>(pTypes.length);
+
+            for (Class<?> pType : pTypes) {
+                retVal.add(new ClassAltClassImpl(pType, helper));
+            }
+
+            parameterTypes = Collections.unmodifiableList(retVal);
+            return parameterTypes;
+        } finally {
+            lock.unlock();
         }
-        
-        parameterTypes = Collections.unmodifiableList(retVal);
-        return parameterTypes;
     }
 
     /* (non-Javadoc)
@@ -143,18 +150,23 @@ public class MethodAltMethodImpl implements AltMethod {
      * @see org.glassfish.hk2.xml.internal.alt.AltMethod#getAnnotations()
      */
     @Override
-    public synchronized List<AltAnnotation> getAnnotations() {
-        if (altAnnotations != null) return altAnnotations;
-        
-        Annotation annotations[] = method.getAnnotations();
-        ArrayList<AltAnnotation> retVal = new ArrayList<AltAnnotation>(annotations.length);
-        
-        for (Annotation annotation : annotations) {
-            retVal.add(new AnnotationAltAnnotationImpl(annotation, helper));
+    public List<AltAnnotation> getAnnotations() {
+        lock.lock();
+        try {
+            if (altAnnotations != null) return altAnnotations;
+
+            Annotation annotations[] = method.getAnnotations();
+            ArrayList<AltAnnotation> retVal = new ArrayList<AltAnnotation>(annotations.length);
+
+            for (Annotation annotation : annotations) {
+                retVal.add(new AnnotationAltAnnotationImpl(annotation, helper));
+            }
+
+            altAnnotations = Collections.unmodifiableList(retVal);
+            return altAnnotations;
+        } finally {
+            lock.unlock();
         }
-        
-        altAnnotations = Collections.unmodifiableList(retVal);
-        return altAnnotations;
     }
 
     /* (non-Javadoc)

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/AnnotationMirrorAltAnnotationImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/AnnotationMirrorAltAnnotationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
@@ -42,6 +43,7 @@ import org.glassfish.hk2.xml.internal.alt.AltEnum;
  *
  */
 public class AnnotationMirrorAltAnnotationImpl implements AltAnnotation {
+    private final ReentrantLock lock = new ReentrantLock();
     private final AnnotationMirror annotation;
     private final ProcessingEnvironment processingEnv;
     private String type;
@@ -56,14 +58,19 @@ public class AnnotationMirrorAltAnnotationImpl implements AltAnnotation {
      * @see org.glassfish.hk2.xml.internal.alt.AltAnnotation#annotationType()
      */
     @Override
-    public synchronized String annotationType() {
-        if (type != null) return type;
-        
-        DeclaredType dt = annotation.getAnnotationType();
-        TypeElement clazzType = (TypeElement) dt.asElement();
-        type = Utilities.convertNameToString(clazzType.getQualifiedName());
-        
-        return type;
+    public String annotationType() {
+        lock.lock();
+        try {
+            if (type != null) return type;
+
+            DeclaredType dt = annotation.getAnnotationType();
+            TypeElement clazzType = (TypeElement) dt.asElement();
+            type = Utilities.convertNameToString(clazzType.getQualifiedName());
+
+            return type;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)
@@ -87,15 +94,20 @@ public class AnnotationMirrorAltAnnotationImpl implements AltAnnotation {
     }
     
     @Override
-    public synchronized String[] getStringArrayValue(String methodName) {
-        getAnnotationValues();
-        
-        Object retVal = values.get(methodName);
-        if (retVal == null || !(retVal instanceof String[])) {
-            return null;
+    public String[] getStringArrayValue(String methodName) {
+        lock.lock();
+        try {
+            getAnnotationValues();
+
+            Object retVal = values.get(methodName);
+            if (retVal == null || !(retVal instanceof String[])) {
+                return null;
+            }
+
+            return (String[]) values.get(methodName);
+        }  finally {
+            lock.unlock();
         }
-        
-        return (String[]) values.get(methodName);
     }
     
     @Override
@@ -116,206 +128,191 @@ public class AnnotationMirrorAltAnnotationImpl implements AltAnnotation {
      * @see org.glassfish.hk2.xml.internal.alt.AltAnnotation#getAnnotationValues()
      */
     @Override
-    public synchronized Map<String, Object> getAnnotationValues() {
-        if (values != null) return values;
-        
-        Map<? extends ExecutableElement, ? extends AnnotationValue> rawValues =
-                processingEnv.getElementUtils().getElementValuesWithDefaults(annotation);
-        Map<String, Object> retVal = new TreeMap<String, Object>();
-        
-        for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : rawValues.entrySet()) {
-            ExecutableElement annoMethod = entry.getKey();
-            AnnotationValue annoValue = entry.getValue();
-            
-            String key = Utilities.convertNameToString(annoMethod.getSimpleName());
-            Object value = annoValue.getValue();
-            
-            if (value instanceof TypeMirror) {
-                // The annotation method is a java.lang.Class
-                value = Utilities.convertTypeMirror((TypeMirror) value, processingEnv);
+    public Map<String, Object> getAnnotationValues() {
+        lock.lock();
+        try {
+            if (values != null) return values;
+
+            Map<? extends ExecutableElement, ? extends AnnotationValue> rawValues =
+                    processingEnv.getElementUtils().getElementValuesWithDefaults(annotation);
+            Map<String, Object> retVal = new TreeMap<String, Object>();
+
+            for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : rawValues.entrySet()) {
+                ExecutableElement annoMethod = entry.getKey();
+                AnnotationValue annoValue = entry.getValue();
+
+                String key = Utilities.convertNameToString(annoMethod.getSimpleName());
+                Object value = annoValue.getValue();
+
+                if (value instanceof TypeMirror) {
+                    // The annotation method is a java.lang.Class
+                    value = Utilities.convertTypeMirror((TypeMirror) value, processingEnv);
+                } else if (value instanceof VariableElement) {
+                    // The annotation method is an Enum
+                    VariableElement variable = (VariableElement) value;
+
+                    TypeElement enclosing = (TypeElement) variable.getEnclosingElement();
+
+                    String annoClassName = Utilities.convertNameToString(enclosing.getQualifiedName());
+                    String annoVal = Utilities.convertNameToString(variable.getSimpleName());
+
+                    value = new StringAltEnumImpl(annoClassName, annoVal);
+                } else if (value instanceof AnnotationMirror) {
+                    throw new AssertionError("The annotation " + annotation + " key " + key + " has unimplemented type AnnotationMirror");
+                } else if (value instanceof List) {
+                    // The annotation method returns an array of something
+                    ArrayType returnType = (ArrayType) annoMethod.getReturnType();
+                    TypeMirror arrayTypeMirror = returnType.getComponentType();
+                    TypeKind arrayTypeKind = arrayTypeMirror.getKind();
+
+                    @SuppressWarnings("unchecked")
+                    List<? extends AnnotationValue> array = ((List<? extends AnnotationValue>) value);
+
+                    if (TypeKind.INT.equals(arrayTypeMirror.getKind())) {
+                        int[] iValue = new int[array.size()];
+
+                        int lcv = 0;
+                        for (AnnotationValue item : array) {
+                            iValue[lcv++] = (Integer) item.getValue();
+                        }
+
+                        value = iValue;
+                    } else if (TypeKind.DECLARED.equals(arrayTypeMirror.getKind())) {
+                        AltClass[] cValue = new AltClass[array.size()];
+                        AltEnum[] eValue = new AltEnum[array.size()];
+                        String[] sValue = new String[array.size()];
+                        AltAnnotation[] aValue = new AltAnnotation[array.size()];
+
+                        boolean isClass = true;
+                        boolean isEnum = true;
+                        boolean isAnnos = false;
+                        int lcv = 0;
+                        for (AnnotationValue item : array) {
+                            Object itemValue = item.getValue();
+                            if (itemValue instanceof TypeMirror) {
+                                isClass = true;
+                                isEnum = false;
+                                isAnnos = false;
+
+                                cValue[lcv++] = Utilities.convertTypeMirror((TypeMirror) itemValue, processingEnv);
+                            } else if (itemValue instanceof VariableElement) {
+                                isClass = false;
+                                isEnum = true;
+                                isAnnos = false;
+
+                                VariableElement variable = (VariableElement) itemValue;
+
+                                TypeElement enclosing = (TypeElement) variable.getEnclosingElement();
+
+                                String annoClassName = Utilities.convertNameToString(enclosing.getQualifiedName());
+                                String annoVal = Utilities.convertNameToString(variable.getSimpleName());
+
+                                eValue[lcv++] = new StringAltEnumImpl(annoClassName, annoVal);
+                            } else if (itemValue instanceof String) {
+                                isClass = false;
+                                isEnum = false;
+                                isAnnos = false;
+
+                                sValue[lcv++] = (String) itemValue;
+                            } else if (itemValue instanceof List) {
+                                throw new AssertionError("Unimplemented declared List type in " + this);
+                            } else if (itemValue instanceof AnnotationMirror) {
+                                isClass = false;
+                                isEnum = false;
+                                isAnnos = true;
+
+                                aValue[lcv++] = new AnnotationMirrorAltAnnotationImpl((AnnotationMirror) itemValue, processingEnv);
+                            } else {
+                                throw new AssertionError("Unknown declared type: " + itemValue.getClass().getName());
+                            }
+                        }
+
+                        if (isClass) {
+                            value = cValue;
+                        } else if (isEnum) {
+                            value = eValue;
+                        } else if (isAnnos) {
+                            value = aValue;
+                        } else {
+                            value = sValue;
+                        }
+                    } else if (TypeKind.LONG.equals(arrayTypeMirror.getKind())) {
+                        long[] iValue = new long[array.size()];
+
+                        int lcv = 0;
+                        for (AnnotationValue item : array) {
+                            iValue[lcv++] = (Long) item.getValue();
+                        }
+
+                        value = iValue;
+                    } else if (TypeKind.SHORT.equals(arrayTypeMirror.getKind())) {
+                        short[] iValue = new short[array.size()];
+
+                        int lcv = 0;
+                        for (AnnotationValue item : array) {
+                            iValue[lcv++] = (Short) item.getValue();
+                        }
+
+                        value = iValue;
+                    } else if (TypeKind.CHAR.equals(arrayTypeMirror.getKind())) {
+                        char[] iValue = new char[array.size()];
+
+                        int lcv = 0;
+                        for (AnnotationValue item : array) {
+                            iValue[lcv++] = (Character) item.getValue();
+                        }
+
+                        value = iValue;
+                    } else if (TypeKind.FLOAT.equals(arrayTypeMirror.getKind())) {
+                        float[] iValue = new float[array.size()];
+
+                        int lcv = 0;
+                        for (AnnotationValue item : array) {
+                            iValue[lcv++] = (Float) item.getValue();
+                        }
+
+                        value = iValue;
+                    } else if (TypeKind.DOUBLE.equals(arrayTypeMirror.getKind())) {
+                        double[] iValue = new double[array.size()];
+
+                        int lcv = 0;
+                        for (AnnotationValue item : array) {
+                            iValue[lcv++] = (Double) item.getValue();
+                        }
+
+                        value = iValue;
+                    } else if (TypeKind.BOOLEAN.equals(arrayTypeMirror.getKind())) {
+                        boolean[] iValue = new boolean[array.size()];
+
+                        int lcv = 0;
+                        for (AnnotationValue item : array) {
+                            iValue[lcv++] = (Boolean) item.getValue();
+                        }
+
+                        value = iValue;
+                    } else if (TypeKind.BYTE.equals(arrayTypeMirror.getKind())) {
+                        byte[] iValue = new byte[array.size()];
+
+                        int lcv = 0;
+                        for (AnnotationValue item : array) {
+                            iValue[lcv++] = (Byte) item.getValue();
+                        }
+
+                        value = iValue;
+
+                    } else {
+                        throw new AssertionError("Array type " + arrayTypeKind + " is not implemented");
+                    }
+                }
+
+                retVal.put(key, value);
             }
-            else if (value instanceof VariableElement) {
-                // The annotation method is an Enum
-                VariableElement variable = (VariableElement) value;
-                
-                TypeElement enclosing = (TypeElement) variable.getEnclosingElement();
-                
-                String annoClassName = Utilities.convertNameToString(enclosing.getQualifiedName());
-                String annoVal = Utilities.convertNameToString(variable.getSimpleName());
-                
-                value = new StringAltEnumImpl(annoClassName, annoVal);
-            }
-            else if (value instanceof AnnotationMirror) {
-                throw new AssertionError("The annotation " + annotation + " key " + key + " has unimplemented type AnnotationMirror");
-            }
-            else if (value instanceof List) {
-                // The annotation method returns an array of something
-                ArrayType returnType = (ArrayType) annoMethod.getReturnType();
-                TypeMirror arrayTypeMirror = returnType.getComponentType();
-                TypeKind arrayTypeKind = arrayTypeMirror.getKind();
-                
-                @SuppressWarnings("unchecked")
-                List<? extends AnnotationValue> array = ((List<? extends AnnotationValue>) value);
-                
-                if (TypeKind.INT.equals(arrayTypeMirror.getKind())) {
-                    int[] iValue = new int[array.size()];
-                    
-                    int lcv = 0;
-                    for (AnnotationValue item : array) {
-                        iValue[lcv++] = (Integer) item.getValue();
-                    }
-                    
-                    value = iValue;
-                }
-                else if (TypeKind.DECLARED.equals(arrayTypeMirror.getKind())) {
-                    AltClass[] cValue = new AltClass[array.size()];
-                    AltEnum[] eValue = new AltEnum[array.size()];
-                    String[] sValue = new String[array.size()];
-                    AltAnnotation[] aValue = new AltAnnotation[array.size()];
-                    
-                    boolean isClass = true;
-                    boolean isEnum = true;
-                    boolean isAnnos = false;
-                    int lcv = 0;
-                    for (AnnotationValue item : array) {
-                        Object itemValue = item.getValue();
-                        if (itemValue instanceof TypeMirror) {
-                            isClass = true;
-                            isEnum = false;
-                            isAnnos = false;
-                            
-                            cValue[lcv++] = Utilities.convertTypeMirror((TypeMirror) itemValue, processingEnv);
-                        }
-                        else if (itemValue instanceof VariableElement) {
-                            isClass = false;
-                            isEnum = true;
-                            isAnnos = false;
-                            
-                            VariableElement variable = (VariableElement) itemValue;
-                            
-                            TypeElement enclosing = (TypeElement) variable.getEnclosingElement();
-                            
-                            String annoClassName = Utilities.convertNameToString(enclosing.getQualifiedName());
-                            String annoVal = Utilities.convertNameToString(variable.getSimpleName());
-                            
-                            eValue[lcv++] = new StringAltEnumImpl(annoClassName, annoVal);
-                        }
-                        else if (itemValue instanceof String) {
-                            isClass = false;
-                            isEnum = false;
-                            isAnnos = false;
-                            
-                            sValue[lcv++] = (String) itemValue;
-                        }
-                        else if (itemValue instanceof List) {
-                            throw new AssertionError("Unimplemented declared List type in " + this);
-                        }
-                        else if (itemValue instanceof AnnotationMirror) {
-                            isClass = false;
-                            isEnum = false;
-                            isAnnos = true;
-                            
-                            aValue[lcv++] = new AnnotationMirrorAltAnnotationImpl((AnnotationMirror) itemValue, processingEnv);
-                        }
-                        else {
-                            throw new AssertionError("Unknown declared type: " + itemValue.getClass().getName());
-                        }
-                    }
-                    
-                    if (isClass) {
-                        value = cValue;
-                    }
-                    else if (isEnum) {
-                        value = eValue;
-                    }
-                    else if (isAnnos) {
-                        value = aValue;
-                    }
-                    else {
-                        value = sValue;
-                    }
-                }
-                else if (TypeKind.LONG.equals(arrayTypeMirror.getKind())) {
-                    long[] iValue = new long[array.size()];
-                    
-                    int lcv = 0;
-                    for (AnnotationValue item : array) {
-                        iValue[lcv++] = (Long) item.getValue();
-                    }
-                    
-                    value = iValue;
-                }
-                else if (TypeKind.SHORT.equals(arrayTypeMirror.getKind())) {
-                    short[] iValue = new short[array.size()];
-                    
-                    int lcv = 0;
-                    for (AnnotationValue item : array) {
-                        iValue[lcv++] = (Short) item.getValue();
-                    }
-                    
-                    value = iValue;
-                }
-                else if (TypeKind.CHAR.equals(arrayTypeMirror.getKind())) {
-                    char[] iValue = new char[array.size()];
-                    
-                    int lcv = 0;
-                    for (AnnotationValue item : array) {
-                        iValue[lcv++] = (Character) item.getValue();
-                    }
-                    
-                    value = iValue;
-                }
-                else if (TypeKind.FLOAT.equals(arrayTypeMirror.getKind())) {
-                    float[] iValue = new float[array.size()];
-                    
-                    int lcv = 0;
-                    for (AnnotationValue item : array) {
-                        iValue[lcv++] = (Float) item.getValue();
-                    }
-                    
-                    value = iValue;
-                }
-                else if (TypeKind.DOUBLE.equals(arrayTypeMirror.getKind())) {
-                    double[] iValue = new double[array.size()];
-                    
-                    int lcv = 0;
-                    for (AnnotationValue item : array) {
-                        iValue[lcv++] = (Double) item.getValue();
-                    }
-                    
-                    value = iValue;
-                }
-                else if (TypeKind.BOOLEAN.equals(arrayTypeMirror.getKind())) {
-                    boolean[] iValue = new boolean[array.size()];
-                    
-                    int lcv = 0;
-                    for (AnnotationValue item : array) {
-                        iValue[lcv++] = (Boolean) item.getValue();
-                    }
-                    
-                    value = iValue;
-                }
-                else if (TypeKind.BYTE.equals(arrayTypeMirror.getKind())) {
-                    byte[] iValue = new byte[array.size()];
-                    
-                    int lcv = 0;
-                    for (AnnotationValue item : array) {
-                        iValue[lcv++] = (Byte) item.getValue();
-                    }
-                    
-                    value = iValue;
-                    
-                }
-                else {
-                    throw new AssertionError("Array type " + arrayTypeKind + " is not implemented");
-                }
-            }
-            
-            retVal.put(key, value);
+
+            values = Collections.unmodifiableMap(retVal);
+            return values;
+        } finally {
+            lock.unlock();
         }
-        
-        values = Collections.unmodifiableMap(retVal);
-        return values;
     }
     
     @Override

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/ArrayTypeAltClassImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/ArrayTypeAltClassImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,7 @@ package org.glassfish.hk2.xml.internal.alt.papi;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.type.ArrayType;
@@ -34,6 +35,7 @@ import org.glassfish.hk2.xml.internal.alt.AltMethod;
  *
  */
 public class ArrayTypeAltClassImpl implements AltClass {
+    private final ReentrantLock lock = new ReentrantLock();
     private final ArrayType arrayType;
     private final ProcessingEnvironment processingEnv;
     private String name;
@@ -123,24 +125,34 @@ public class ArrayTypeAltClassImpl implements AltClass {
      * @see org.glassfish.hk2.xml.internal.alt.AltClass#getName()
      */
     @Override
-    public synchronized String getName() {
-        if (name != null) return name;
-        
-        calculateNames();
-        
-        return name;
+    public String getName() {
+        lock.lock();
+        try {
+            if (name != null) return name;
+
+            calculateNames();
+
+            return name;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.xml.internal.alt.AltClass#getSimpleName()
      */
     @Override
-    public synchronized String getSimpleName() {
-        if (simpleName != null) return simpleName;
-        
-        calculateNames();
-        
-        return simpleName;
+    public String getSimpleName() {
+        lock.lock();
+        try {
+            if (simpleName != null) return simpleName;
+
+            calculateNames();
+
+            return simpleName;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/ElementAltMethodImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/ElementAltMethodImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
@@ -45,6 +46,7 @@ import org.glassfish.hk2.xml.internal.alt.clazz.ClassAltClassImpl;
  *
  */
 public class ElementAltMethodImpl implements AltMethod {
+    private final ReentrantLock lock = new ReentrantLock();
     private final ExecutableElement method;
     private final ProcessingEnvironment processingEnv;
     private List<AltClass> parameters;
@@ -69,36 +71,46 @@ public class ElementAltMethodImpl implements AltMethod {
      * @see org.glassfish.hk2.xml.internal.alt.AltMethod#getReturnType()
      */
     @Override
-    public synchronized AltClass getReturnType() {
-        if (returnType != null) return returnType;
-        
-        ExecutableType executable = (ExecutableType) method.asType();
-        TypeMirror returnMirror = executable.getReturnType();
-        
-        AltClass retVal = Utilities.convertTypeMirror(returnMirror, processingEnv);
-        
-        returnType = retVal;
-        return returnType;
+    public AltClass getReturnType() {
+        lock.lock();
+        try {
+            if (returnType != null) return returnType;
+
+            ExecutableType executable = (ExecutableType) method.asType();
+            TypeMirror returnMirror = executable.getReturnType();
+
+            AltClass retVal = Utilities.convertTypeMirror(returnMirror, processingEnv);
+
+            returnType = retVal;
+            return returnType;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.xml.internal.alt.AltMethod#getParameterTypes()
      */
     @Override
-    public synchronized List<AltClass> getParameterTypes() {
-        if (parameters != null) return parameters;
-        
-        ExecutableType executable = (ExecutableType) method.asType();
-        List<? extends TypeMirror> paramMirrors = executable.getParameterTypes();
-        
-        List<AltClass> retVal = new ArrayList<AltClass>(paramMirrors.size());
-        
-        for (TypeMirror paramMirror : paramMirrors) {
-            retVal.add(Utilities.convertTypeMirror(paramMirror, processingEnv));
+    public List<AltClass> getParameterTypes() {
+        lock.lock();
+        try {
+            if (parameters != null) return parameters;
+
+            ExecutableType executable = (ExecutableType) method.asType();
+            List<? extends TypeMirror> paramMirrors = executable.getParameterTypes();
+
+            List<AltClass> retVal = new ArrayList<AltClass>(paramMirrors.size());
+
+            for (TypeMirror paramMirror : paramMirrors) {
+                retVal.add(Utilities.convertTypeMirror(paramMirror, processingEnv));
+            }
+
+            parameters = Collections.unmodifiableList(retVal);
+            return parameters;
+        }  finally {
+            lock.unlock();
         }
-        
-        parameters = Collections.unmodifiableList(retVal);
-        return parameters;
     }
 
     /* (non-Javadoc)
@@ -154,33 +166,43 @@ public class ElementAltMethodImpl implements AltMethod {
      * @see org.glassfish.hk2.xml.internal.alt.AltMethod#getAnnotation(java.lang.String)
      */
     @Override
-    public synchronized AltAnnotation getAnnotation(String annotation) {
-        if (annotations == null) {
-            getAnnotations();
+    public AltAnnotation getAnnotation(String annotation) {
+        lock.lock();
+        try {
+            if (annotations == null) {
+                getAnnotations();
+            }
+
+            return annotations.get(annotation);
+        } finally {
+            lock.unlock();
         }
-        
-        return annotations.get(annotation);
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.xml.internal.alt.AltMethod#getAnnotations()
      */
     @Override
-    public synchronized List<AltAnnotation> getAnnotations() {
-        if (annotations != null) {
+    public List<AltAnnotation> getAnnotations() {
+        lock.lock();
+        try {
+            if (annotations != null) {
+                return Collections.unmodifiableList(new ArrayList<AltAnnotation>(annotations.values()));
+            }
+
+            Map<String, AltAnnotation> retVal = new LinkedHashMap<String, AltAnnotation>();
+
+            for (AnnotationMirror annoMirror : method.getAnnotationMirrors()) {
+                AnnotationMirrorAltAnnotationImpl addMe = new AnnotationMirrorAltAnnotationImpl(annoMirror, processingEnv);
+
+                retVal.put(addMe.annotationType(), addMe);
+            }
+
+            annotations = Collections.unmodifiableMap(retVal);
             return Collections.unmodifiableList(new ArrayList<AltAnnotation>(annotations.values()));
+        } finally {
+            lock.unlock();
         }
-        
-        Map<String, AltAnnotation> retVal = new LinkedHashMap<String, AltAnnotation>();
-        
-        for (AnnotationMirror annoMirror : method.getAnnotationMirrors()) {
-            AnnotationMirrorAltAnnotationImpl addMe = new AnnotationMirrorAltAnnotationImpl(annoMirror, processingEnv);
-            
-            retVal.put(addMe.annotationType(), addMe);
-        }
-        
-        annotations = Collections.unmodifiableMap(retVal);
-        return Collections.unmodifiableList(new ArrayList<AltAnnotation>(annotations.values()));
     }
     
     @Override

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/TypeElementAltClassImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/TypeElementAltClassImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
@@ -48,6 +49,7 @@ import org.glassfish.hk2.xml.internal.alt.clazz.ClassAltClassImpl;
  *
  */
 public class TypeElementAltClassImpl implements AltClass {
+    private final ReentrantLock lock = new ReentrantLock();
     private final TypeElement clazz;
     private final ProcessingEnvironment processingEnv;
     
@@ -79,21 +81,26 @@ public class TypeElementAltClassImpl implements AltClass {
      * @see org.glassfish.hk2.xml.internal.alt.AltClass#getAnnotations()
      */
     @Override
-    public synchronized List<AltAnnotation> getAnnotations() {
-        if (annotations != null) return annotations;
-        
-        List<? extends AnnotationMirror> annoMirrors = processingEnv.getElementUtils().getAllAnnotationMirrors(clazz);
-        
-        ArrayList<AltAnnotation> retVal = new ArrayList<AltAnnotation>(annoMirrors.size());
-        
-        for (AnnotationMirror annoMirror : annoMirrors) {
-            AnnotationMirrorAltAnnotationImpl anno = new AnnotationMirrorAltAnnotationImpl(annoMirror, processingEnv);
-            
-            retVal.add(anno);
+    public List<AltAnnotation> getAnnotations() {
+        lock.lock();
+        try {
+            if (annotations != null) return annotations;
+
+            List<? extends AnnotationMirror> annoMirrors = processingEnv.getElementUtils().getAllAnnotationMirrors(clazz);
+
+            ArrayList<AltAnnotation> retVal = new ArrayList<AltAnnotation>(annoMirrors.size());
+
+            for (AnnotationMirror annoMirror : annoMirrors) {
+                AnnotationMirrorAltAnnotationImpl anno = new AnnotationMirrorAltAnnotationImpl(annoMirror, processingEnv);
+
+                retVal.add(anno);
+            }
+
+            annotations = Collections.unmodifiableList(new ArrayList<AltAnnotation>(retVal));
+            return annotations;
+        } finally {
+            lock.unlock();
         }
-        
-        annotations = Collections.unmodifiableList(new ArrayList<AltAnnotation>(retVal));
-        return annotations;
     }
     
     private static final Set<String> POSSIBLE_NO_HANDLE = new HashSet<String>(Arrays.asList(new String[] {
@@ -164,51 +171,56 @@ public class TypeElementAltClassImpl implements AltClass {
      * @see org.glassfish.hk2.xml.internal.alt.AltClass#getMethods()
      */
     @Override
-    public synchronized List<AltMethod> getMethods() {
-        if (methods != null) return methods;
-        
-        List<? extends Element> innerElements = processingEnv.getElementUtils().getAllMembers(clazz);
-        
-        TreeMap<String, List<Element>> reorderByEnclosingClass = new TreeMap<String, List<Element>>();
-        
-        String clazzName = getName();
-        for (Element innerElementElement : innerElements) {
-            if (isMethodToGenerate(innerElementElement)) {
-                TypeElement enclosingElement = (TypeElement) innerElementElement.getEnclosingElement();
-                
-                String enclosingName = Utilities.convertNameToString(processingEnv.getElementUtils().getBinaryName(enclosingElement));
-                
-                List<Element> addedList = reorderByEnclosingClass.get(enclosingName);
-                if (addedList == null) {
-                    addedList = new LinkedList<Element>();
-                    
-                    reorderByEnclosingClass.put(enclosingName, addedList);
+    public List<AltMethod> getMethods() {
+        lock.lock();
+        try {
+            if (methods != null) return methods;
+
+            List<? extends Element> innerElements = processingEnv.getElementUtils().getAllMembers(clazz);
+
+            TreeMap<String, List<Element>> reorderByEnclosingClass = new TreeMap<String, List<Element>>();
+
+            String clazzName = getName();
+            for (Element innerElementElement : innerElements) {
+                if (isMethodToGenerate(innerElementElement)) {
+                    TypeElement enclosingElement = (TypeElement) innerElementElement.getEnclosingElement();
+
+                    String enclosingName = Utilities.convertNameToString(processingEnv.getElementUtils().getBinaryName(enclosingElement));
+
+                    List<Element> addedList = reorderByEnclosingClass.get(enclosingName);
+                    if (addedList == null) {
+                        addedList = new LinkedList<Element>();
+
+                        reorderByEnclosingClass.put(enclosingName, addedList);
+                    }
+
+                    addedList.add(innerElementElement);
                 }
-                
-                addedList.add(innerElementElement);
             }
+
+            List<Element> innerElementsReordered = new ArrayList<Element>(innerElements.size());
+            for (Map.Entry<String, List<Element>> listByEnclosing : reorderByEnclosingClass.entrySet()) {
+                String enclosingClass = listByEnclosing.getKey();
+                if (clazzName.equals(enclosingClass)) continue;
+
+                innerElementsReordered.addAll(listByEnclosing.getValue());
+            }
+
+            List<Element> topClass = reorderByEnclosingClass.get(clazzName);
+            if (topClass != null) {
+                innerElementsReordered.addAll(topClass);
+            }
+
+            ArrayList<AltMethod> retVal = new ArrayList<AltMethod>(innerElementsReordered.size());
+            for (Element innerElementElement : innerElementsReordered) {
+                retVal.add(new ElementAltMethodImpl(innerElementElement, processingEnv));
+            }
+
+            methods = Collections.unmodifiableList(retVal);
+            return methods;
+        } finally {
+            lock.unlock();
         }
-        
-        List<Element> innerElementsReordered = new ArrayList<Element>(innerElements.size());
-        for (Map.Entry<String, List<Element>> listByEnclosing : reorderByEnclosingClass.entrySet()) {
-            String enclosingClass = listByEnclosing.getKey();
-            if (clazzName.equals(enclosingClass)) continue;
-            
-            innerElementsReordered.addAll(listByEnclosing.getValue());
-        }
-        
-        List<Element> topClass = reorderByEnclosingClass.get(clazzName);
-        if (topClass != null) {
-            innerElementsReordered.addAll(topClass);
-        }
-        
-        ArrayList<AltMethod> retVal = new ArrayList<AltMethod>(innerElementsReordered.size());
-        for (Element innerElementElement : innerElementsReordered) {
-            retVal.add(new ElementAltMethodImpl(innerElementElement, processingEnv));
-        }
-        
-        methods = Collections.unmodifiableList(retVal);
-        return methods;
     }
     
     @Override

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/jaxb/internal/BaseHK2JAXBBean.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/jaxb/internal/BaseHK2JAXBBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.namespace.QName;
@@ -79,6 +80,8 @@ public abstract class BaseHK2JAXBBean implements XmlHk2ConfigurationBean, Serial
     
     private final static String EMPTY = "";
     public final static char XML_PATH_SEPARATOR = '/';
+
+    private final ReentrantLock lock = new ReentrantLock();
     
     /**
      * All fields, including child lists and direct children for beans
@@ -221,8 +224,11 @@ public abstract class BaseHK2JAXBBean implements XmlHk2ConfigurationBean, Serial
         
         if (changeControl == null) {
             if (active) {
-                synchronized (this) {
+                lock.lock();
+                try {
                     nBeanLikeMap.setValue(propNamespace, propName, propValue);
+                } finally {
+                    lock.unlock();
                 }
             }
             else {
@@ -434,9 +440,12 @@ public abstract class BaseHK2JAXBBean implements XmlHk2ConfigurationBean, Serial
         
         if (changeControl == null) {
             if (active) {
-                synchronized (this) {
+                lock.lock();
+                try {
                     isSet = nBeanLikeMap.isSet(propNamespace, propName);
                     retVal = nBeanLikeMap.getValue(propNamespace, propName);
+                } finally {
+                    lock.unlock();
                 }
             }
             else {
@@ -933,8 +942,11 @@ public abstract class BaseHK2JAXBBean implements XmlHk2ConfigurationBean, Serial
     public boolean _hasProperty(String propNamespace, String propName) {
         if (changeControl == null) {
             if (active) {
-                synchronized (this) {
+                lock.lock();
+                try {
                     return nBeanLikeMap.isSet(propNamespace, propName);
+                } finally {
+                    lock.unlock();
                 }
             }
             
@@ -957,8 +969,11 @@ public abstract class BaseHK2JAXBBean implements XmlHk2ConfigurationBean, Serial
     public Map<String, Object> _getBeanLikeMap() {
         if (changeControl == null) {
             if (active) {
-                synchronized (this) {
+                lock.lock();
+                try {
                     return Collections.unmodifiableMap(nBeanLikeMap.getBeanLikeMap(namespaceToPrefixMap));
+                } finally {
+                    lock.unlock();
                 }
             }
             return Collections.unmodifiableMap(nBeanLikeMap.getBeanLikeMap(namespaceToPrefixMap));
@@ -976,8 +991,11 @@ public abstract class BaseHK2JAXBBean implements XmlHk2ConfigurationBean, Serial
     public Map<QName, Object> _getQNameMap() {
         if (changeControl == null) {
             if (active) {
-                synchronized (this) {
+                lock.lock();
+                try {
                     return Collections.unmodifiableMap(nBeanLikeMap.getQNameMap());
+                } finally {
+                    lock.unlock();
                 }
             }
             return Collections.unmodifiableMap(nBeanLikeMap.getQNameMap());
@@ -1300,8 +1318,11 @@ public abstract class BaseHK2JAXBBean implements XmlHk2ConfigurationBean, Serial
     public boolean _isSet(String propNamespace, String propName) {
         if (changeControl == null) {
             if (active) {
-                synchronized (this) {
+                lock.lock();
+                try {
                     return nBeanLikeMap.isSet(propNamespace, propName);
+                } finally {
+                    lock.unlock();
                 }
             }
             

--- a/hk2-configuration/persistence/property-file/src/main/java/org/glassfish/hk2/configuration/persistence/properties/PropertyFileBean.java
+++ b/hk2-configuration/persistence/property-file/src/main/java/org/glassfish/hk2/configuration/persistence/properties/PropertyFileBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,7 @@ package org.glassfish.hk2.configuration.persistence.properties;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * This bean configures the PropertyFileService itself.  An implementation
@@ -34,6 +35,8 @@ public class PropertyFileBean {
     
     /** The name of the single instance of this bean */
     public final static String INSTANCE_NAME = "DEFAULT";
+
+    private final ReentrantLock lock = new ReentrantLock();
     
     private final HashMap<String, Class<?>> mapping = new HashMap<String, Class<?>>();
     
@@ -58,8 +61,11 @@ public class PropertyFileBean {
      * @return A copy of the type name to bean class mapping
      */
     public Map<String, Class<?>> getTypeMapping() {
-        synchronized (mapping) {
+        lock.lock();
+        try {
             return new HashMap<String, Class<?>>(mapping);
+        } finally {
+            lock.unlock();
         }
     }
     
@@ -71,8 +77,11 @@ public class PropertyFileBean {
      * May not be null
      */
     public void addTypeMapping(String typeName, Class<?> beanClass) {
-        synchronized (mapping) {
+        lock.lock();
+        try {
             mapping.put(typeName, beanClass);
+        } finally {
+            lock.unlock();
         }
     }
     
@@ -85,8 +94,11 @@ public class PropertyFileBean {
      * was no type mapping with the given name
      */
     public Class<?> removeTypeMapping(String typeName) {
-        synchronized (mapping) {
+        lock.lock();
+        try {
             return mapping.remove(typeName);
+        } finally {
+            lock.unlock();
         }
     }
     
@@ -99,8 +111,11 @@ public class PropertyFileBean {
      * was no type mapping with the given name
      */
     public Class<?> getTypeMapping(String typeName) {
-        synchronized (mapping) {
+        lock.lock();
+        try {
             return mapping.get(typeName);
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/hk2-configuration/persistence/property-file/src/main/java/org/glassfish/hk2/configuration/persistence/properties/internal/PropertyFileHandleImpl.java
+++ b/hk2-configuration/persistence/property-file/src/main/java/org/glassfish/hk2/configuration/persistence/properties/internal/PropertyFileHandleImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,6 +26,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.configuration.hub.api.Hub;
 import org.glassfish.hk2.configuration.hub.api.Instance;
@@ -48,8 +49,8 @@ import org.jvnet.hk2.annotations.Service;
 public class PropertyFileHandleImpl implements PropertyFileHandle {
     private final static int MAX_TRIES = 10000;
     private final static char SEPARATOR = '.';
-    
-    private final Object lock = new Object();
+
+    private final ReentrantLock lock = new ReentrantLock();
     private HashMap<TypeData, Map<String, String>> lastRead = new HashMap<TypeData, Map<String, String>>();
     private boolean open = true;
     
@@ -392,7 +393,8 @@ public class PropertyFileHandleImpl implements PropertyFileHandle {
             extractData(sFullKey, value, allBeans);
         }
         
-        synchronized (lock) {
+        lock.lock();
+        try {
             if (!open) {
                 throw new IllegalStateException("This handle has been closed");
             }
@@ -422,6 +424,8 @@ public class PropertyFileHandleImpl implements PropertyFileHandle {
             }
             
             lastRead = allBeans;
+        }  finally {
+            lock.unlock();
         }
     }
     
@@ -476,7 +480,8 @@ public class PropertyFileHandleImpl implements PropertyFileHandle {
      */
     @Override
     public void dispose() {
-        synchronized (lock) {
+        lock.lock();
+        try {
             if (!open) return;
             open = false;
             
@@ -500,6 +505,8 @@ public class PropertyFileHandleImpl implements PropertyFileHandle {
             
             // success or not
             lastRead = allBeans;
+        } finally {
+            lock.unlock();
         }
 
     }

--- a/hk2-core/src/main/java/com/sun/enterprise/module/ModuleMetadata.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/ModuleMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.net.URL;
 import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Holds information about /META-INF/services and /META-INF/inhabitants for a {@link Module}.
@@ -41,6 +42,7 @@ import java.util.*;
  */
 public final class ModuleMetadata implements Serializable {
 
+    private final ReentrantLock lock = new ReentrantLock();
     /**
      * META-INF/hk2-locator/* cache
      */
@@ -50,16 +52,21 @@ public final class ModuleMetadata implements Serializable {
         return descriptors;
     }
 
-    public synchronized void addDescriptors(String serviceLocatorName, Collection<Descriptor> descriptorsToAdd) {
-        List<Descriptor> descriptorList = descriptors.get(serviceLocatorName);
+    public void addDescriptors(String serviceLocatorName, Collection<Descriptor> descriptorsToAdd) {
+        lock.lock();
+        try {
+            List<Descriptor> descriptorList = descriptors.get(serviceLocatorName);
 
-        if (descriptorList == null) {
-            descriptorList = new ArrayList<Descriptor>();
+            if (descriptorList == null) {
+                descriptorList = new ArrayList<Descriptor>();
 
-            descriptors.put(serviceLocatorName, descriptorList);
+                descriptors.put(serviceLocatorName, descriptorList);
+            }
+
+            descriptorList.addAll(descriptorsToAdd);
+        } finally {
+            lock.unlock();
         }
-
-        descriptorList.addAll(descriptorsToAdd);
     }
 
     public static final class Entry implements Serializable {

--- a/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/AbstractModulesRegistryImpl.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/AbstractModulesRegistryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -43,6 +43,7 @@ import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Logger;
 
 import org.glassfish.hk2.api.ActiveDescriptor;
@@ -78,6 +79,7 @@ public abstract class AbstractModulesRegistryImpl implements ModulesRegistry {
 
     protected final Map<Integer,Repository> repositories = new TreeMap<Integer,Repository>();
 
+    private final ReentrantLock lock = new ReentrantLock();
     private final ConcurrentMap<Class<?>, CopyOnWriteArrayList<?>> runningServices = 
       new ConcurrentHashMap<Class<?>,CopyOnWriteArrayList<?>>();
 
@@ -221,17 +223,22 @@ public abstract class AbstractModulesRegistryImpl implements ModulesRegistry {
      * @param repository new repository to attach to this registry
      * @param weight int value from 1 to 100 to specify the search order
      */
-    public synchronized void addRepository(Repository repository, int weight) {
-        // check that we don't already have this repository
-        for (Repository repo : repositories.values()) {
-            if (repo.getLocation().equals(repository.getLocation())) {
-                throw new RuntimeException("repository at " + repository.getLocation() + " already registered");
+    public void addRepository(Repository repository, int weight) {
+        lock.lock();
+        try {
+            // check that we don't already have this repository
+            for (Repository repo : repositories.values()) {
+                if (repo.getLocation().equals(repository.getLocation())) {
+                    throw new RuntimeException("repository at " + repository.getLocation() + " already registered");
+                }
             }
+            while (repositories.containsKey(weight)) {
+                weight++;
+            }
+            repositories.put(weight, repository);
+        }  finally {
+            lock.unlock();
         }
-        while (repositories.containsKey(weight)) {
-            weight++;
-        }
-        repositories.put(weight, repository);
     }
     
     /**
@@ -240,8 +247,13 @@ public abstract class AbstractModulesRegistryImpl implements ModulesRegistry {
      * registered in this instance.
      * @param repository new repository to attach to this registry
      */
-    public synchronized void addRepository(Repository repository) {
-        repositories.put(100+repositories.size(), repository);
+    public void addRepository(Repository repository) {
+        lock.lock();
+        try {
+            repositories.put(100 + repositories.size(), repository);
+        }  finally {
+            lock.unlock();
+        }
     }
     
     /**
@@ -251,13 +263,18 @@ public abstract class AbstractModulesRegistryImpl implements ModulesRegistry {
      * longer
      * @param name name of the repository to remove
      */
-    public synchronized void removeRepository(String name) {
-        for (Integer weight : repositories.keySet()) {
-            Repository repo = repositories.get(weight);
-            if (repo.getName().equals(name)) {
-                repositories.remove(weight);
-                return;
+    public void removeRepository(String name) {
+        lock.lock();
+        try {
+            for (Integer weight : repositories.keySet()) {
+                Repository repo = repositories.get(weight);
+                if (repo.getName().equals(name)) {
+                    repositories.remove(weight);
+                    return;
+                }
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -267,14 +284,19 @@ public abstract class AbstractModulesRegistryImpl implements ModulesRegistry {
      * @param name name of the repository to return
      * @return the repository or null if not found
      */
-    public synchronized Repository getRepository(String name) {
-        for (Integer weight : repositories.keySet()) {
-            Repository repo = repositories.get(weight);
-            if (repo.getName().equals(name)) {
-                return repo;
+    public Repository getRepository(String name) {
+        lock.lock();
+        try {
+            for (Integer weight : repositories.keySet()) {
+                Repository repo = repositories.get(weight);
+                if (repo.getName().equals(name)) {
+                    return repo;
+                }
             }
+            return null;
+        } finally {
+            lock.unlock();
         }
-        return null;
     }
 
     /**
@@ -537,8 +559,13 @@ public abstract class AbstractModulesRegistryImpl implements ModulesRegistry {
      * definition, the registry will be capable of created shared and private
      * <code>HK2Module</code> instances.
      */
-    public synchronized HK2Module add(ModuleDefinition info) throws ResolveError {
-        return add(info, true);
+    public HK2Module add(ModuleDefinition info) throws ResolveError {
+        lock.lock();
+        try {
+            return add(info, true);
+        }  finally {
+            lock.unlock();
+        }
     }
 
     public HK2Module add(ModuleDefinition info, boolean resolve) throws ResolveError {

--- a/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/AbstractRepositoryImpl.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/AbstractRepositoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,6 +24,7 @@ import com.sun.enterprise.module.ManifestConstants;
 import java.io.*;
 import java.net.URI;
 import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
@@ -37,6 +38,7 @@ import java.util.jar.Manifest;
  * @author Sanjeeb.Sahoo@Sun.COM
  */
 public abstract class AbstractRepositoryImpl implements Repository {
+    private final ReentrantLock lock = new ReentrantLock();
     private final String name;
     private final URI location;
     private Map<ModuleId, ModuleDefinition> moduleDefs;
@@ -189,11 +191,16 @@ public abstract class AbstractRepositoryImpl implements Repository {
      * @param listener implementation listening to this repository changes
      * @return true if the listener was added successfully
      */
-    public synchronized boolean addListener(RepositoryChangeListener listener) {
-        if (listeners==null) {
-            listeners = new ArrayList<RepositoryChangeListener>();
+    public boolean addListener(RepositoryChangeListener listener) {
+        lock.lock();
+        try {
+            if (listeners == null) {
+                listeners = new ArrayList<RepositoryChangeListener>();
+            }
+            return listeners.add(listener);
+        } finally {
+            lock.unlock();
         }
-        return listeners.add(listener);
     }
 
     /**
@@ -202,11 +209,16 @@ public abstract class AbstractRepositoryImpl implements Repository {
      * @param listener the previously registered listener
      * @return true if the listener was successfully unregistered
      */
-    public synchronized boolean removeListener(RepositoryChangeListener listener) {
-        if (listeners==null) {
-            return false;
+    public boolean removeListener(RepositoryChangeListener listener) {
+        lock.lock();
+        try {
+            if (listeners == null) {
+                return false;
+            }
+            return listeners.remove(listener);
+        } finally {
+            lock.unlock();
         }
-        return listeners.remove(listener);
     }
 
     /**

--- a/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/DirectoryBasedRepository.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/DirectoryBasedRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * This class is a directory based repository implementation. This mean that all jar
@@ -43,6 +44,7 @@ import java.util.TimerTask;
 public class DirectoryBasedRepository extends AbstractRepositoryImpl {
     
     protected final File repository;
+    private final ReentrantLock lock = new ReentrantLock();
     private final int intervalInMs = Integer.getInteger("hk2.file.directory.changeIntervalTimer", 1000);
     private Timer timer;
     private boolean isTimerThreadDaemon = false;
@@ -75,28 +77,36 @@ public class DirectoryBasedRepository extends AbstractRepositoryImpl {
     }
 
     @Override
-    public synchronized boolean addListener(RepositoryChangeListener listener) {
+    public boolean addListener(RepositoryChangeListener listener) {
+        lock.lock();
+        try {
+            final boolean returnValue = super.addListener(listener);
+            if (returnValue && timer == null) {
+                initializeSubDirectories();
 
-        final boolean returnValue = super.addListener(listener);
-        if (returnValue && timer==null) {
-            initializeSubDirectories();
-            
-            timer = new Timer("hk2-repo-listener-"+ this.getName(), isTimerThreadDaemon);
-            timer.schedule(new TimerTask() {
-                long lastModified = repository.lastModified();
-                public void run() {
-                    synchronized(this) {
-                        if (lastModified<repository.lastModified()) {
-                            lastModified = repository.lastModified();
-                            // something has changed, look into this...
-                            directoryChanged();
+                timer = new Timer("hk2-repo-listener-" + this.getName(), isTimerThreadDaemon);
+                timer.schedule(new TimerTask() {
+                    long lastModified = repository.lastModified();
+
+                    public void run() {
+                        lock.lock();
+                        try {
+                            if (lastModified < repository.lastModified()) {
+                                lastModified = repository.lastModified();
+                                // something has changed, look into this...
+                                directoryChanged();
+                            }
+                        } finally {
+                            lock.unlock();
                         }
                     }
-                }
-            }, intervalInMs, intervalInMs);
-            timer.purge();
+                }, intervalInMs, intervalInMs);
+                timer.purge();
+            }
+            return returnValue;
+        } finally {
+            lock.unlock();
         }
-        return returnValue;        
     }
 
     @Override
@@ -145,85 +155,89 @@ public class DirectoryBasedRepository extends AbstractRepositoryImpl {
         return disabledFile.exists();
     }
 
-    private synchronized void directoryChanged() {
-
-        // not the most efficient implementation, could be revisited later
-        HashMap<ModuleId, ModuleDefinition> newModuleDefs =
-                new HashMap<ModuleId, ModuleDefinition>();
-        List<URI> libraries = new LinkedList<URI>();
-
+    private void directoryChanged() {
+        lock.lock();
         try {
-            loadModuleDefs(newModuleDefs, libraries);
-        } catch(IOException ioe) {
-            // we probably need to wait until the jar has finished being copied
-            // XXX add some form of retry
-        }
-        for(ModuleDefinition def : newModuleDefs.values()) {
-            if (find(def.getName(), def.getVersion())==null) {
-                add(def);
-                for (RepositoryChangeListener listener : listeners) {
-                    listener.moduleAdded(def);
-                }
+            // not the most efficient implementation, could be revisited later
+            HashMap<ModuleId, ModuleDefinition> newModuleDefs =
+                    new HashMap<ModuleId, ModuleDefinition>();
+            List<URI> libraries = new LinkedList<URI>();
+
+            try {
+                loadModuleDefs(newModuleDefs, libraries);
+            } catch (IOException ioe) {
+                // we probably need to wait until the jar has finished being copied
+                // XXX add some form of retry
             }
-        }
-        for (ModuleDefinition def : findAll()) {
-            if (!newModuleDefs.containsKey(AbstractFactory.getInstance().createModuleId(def))) {
-                remove(def);
-                for (RepositoryChangeListener listener : listeners) {
-                    listener.moduleRemoved(def);
-                }
-            }
-        }
-        List<URI> originalLibraries = super.getJarLocations();
-        for (URI location : libraries) {
-            if (!originalLibraries.contains(location)) {
-                addLibrary(location);
-                for (RepositoryChangeListener listener : listeners) {
-                    listener.added(location);
-                }
-            }
-        }
-        if (originalLibraries.size()>0) {
-            List<URI> copy = new LinkedList<URI>();
-            copy.addAll(originalLibraries);
-            for (URI originalLocation : copy) {
-                if (!libraries.contains(originalLocation)) {
-                    removeLibrary(originalLocation);
+            for (ModuleDefinition def : newModuleDefs.values()) {
+                if (find(def.getName(), def.getVersion()) == null) {
+                    add(def);
                     for (RepositoryChangeListener listener : listeners) {
-                        listener.removed(originalLocation);
+                        listener.moduleAdded(def);
                     }
                 }
             }
-        }
+            for (ModuleDefinition def : findAll()) {
+                if (!newModuleDefs.containsKey(AbstractFactory.getInstance().createModuleId(def))) {
+                    remove(def);
+                    for (RepositoryChangeListener listener : listeners) {
+                        listener.moduleRemoved(def);
+                    }
+                }
+            }
+            List<URI> originalLibraries = super.getJarLocations();
+            for (URI location : libraries) {
+                if (!originalLibraries.contains(location)) {
+                    addLibrary(location);
+                    for (RepositoryChangeListener listener : listeners) {
+                        listener.added(location);
+                    }
+                }
+            }
+            if (originalLibraries.size() > 0) {
+                List<URI> copy = new LinkedList<URI>();
+                copy.addAll(originalLibraries);
+                for (URI originalLocation : copy) {
+                    if (!libraries.contains(originalLocation)) {
+                        removeLibrary(originalLocation);
+                        for (RepositoryChangeListener listener : listeners) {
+                            listener.removed(originalLocation);
+                        }
+                    }
+                }
+            }
 
-        // added or removed subdirectories ?
-        List<File> previous = new LinkedList<File>();
-        previous.addAll(subDirectories);
-        for (File file : repository.listFiles(new FileFilter() {
-            public boolean accept(File pathname) {
-                return pathname.isDirectory();
-            }
-        })) {
-            // added ?
-            if (!subDirectories.contains(file)) {
-                for (RepositoryChangeListener listener : listeners) {
-                    listener.added(file.toURI());
+            // added or removed subdirectories ?
+            List<File> previous = new LinkedList<File>();
+            previous.addAll(subDirectories);
+            for (File file : repository.listFiles(new FileFilter() {
+                public boolean accept(File pathname) {
+                    return pathname.isDirectory();
                 }
-                subDirectories.add(file);
-            }  else {
-                // known, removing it from the copied list to check
-                // for removal
-                previous.remove(file);
-            }
-        }
-        // any left in our copy is a removed sub directory.
-        if (!previous.isEmpty()) {
-            for (File file : previous) {
-                 for (RepositoryChangeListener listener : listeners) {
-                    listener.removed(file.toURI());
+            })) {
+                // added ?
+                if (!subDirectories.contains(file)) {
+                    for (RepositoryChangeListener listener : listeners) {
+                        listener.added(file.toURI());
+                    }
+                    subDirectories.add(file);
+                } else {
+                    // known, removing it from the copied list to check
+                    // for removal
+                    previous.remove(file);
                 }
-                subDirectories.remove(file);
             }
+            // any left in our copy is a removed sub directory.
+            if (!previous.isEmpty()) {
+                for (File file : previous) {
+                    for (RepositoryChangeListener listener : listeners) {
+                        listener.removed(file.toURI());
+                    }
+                    subDirectories.remove(file);
+                }
+            }
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/hk2-core/src/main/java/com/sun/enterprise/module/impl/ClassLoaderProxy.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/impl/ClassLoaderProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,7 @@ import java.net.URLClassLoader;
 import java.net.URL;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.locks.ReentrantLock;
 import java.io.IOException;
 
 /**
@@ -31,6 +32,7 @@ import java.io.IOException;
  */
 public class ClassLoaderProxy extends URLClassLoader {
 
+    private final ReentrantLock lock = new ReentrantLock();
     private final List<ClassLoader> surrogates = new CopyOnWriteArrayList<ClassLoader>();
     private final List<ClassLoaderFacade> facadeSurrogates = new CopyOnWriteArrayList<ClassLoaderFacade>();
 
@@ -116,13 +118,18 @@ public class ClassLoaderProxy extends URLClassLoader {
     /**
      * {@link #findClass(String)} except the classloader punch-in hack.
      */
-    /*package*/ synchronized Class findClassDirect(String name) throws ClassNotFoundException {
-        Class c = findLoadedClass(name);
-        if(c!=null) return c;
+    /*package*/ Class findClassDirect(String name) throws ClassNotFoundException {
+        lock.lock();
         try {
-            return super.findClass(name);
-        } catch (NoClassDefFoundError e) {
-            throw new ClassNotFoundException(e.getMessage());
+            Class c = findLoadedClass(name);
+            if (c != null) return c;
+            try {
+                return super.findClass(name);
+            } catch (NoClassDefFoundError e) {
+                throw new ClassNotFoundException(e.getMessage());
+            }
+        }  finally {
+            lock.unlock();
         }
     }
 

--- a/hk2-core/src/main/java/com/sun/enterprise/module/impl/HK2Factory.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/impl/HK2Factory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,17 +21,25 @@ import com.sun.enterprise.module.common_impl.LogHelper;
 import com.sun.enterprise.module.common_impl.ModuleId;
 import com.sun.enterprise.module.ModulesRegistry;
 import com.sun.enterprise.module.ModuleDefinition;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * @author Sanjeeb.Sahoo@Sun.COM
  */
 public class HK2Factory extends AbstractFactory {
 
-    public synchronized static void initialize() {
-        if (Instance != null) {
-            LogHelper.getDefaultLogger().fine("Singleton already initialized as " + getInstance());
+    private static final ReentrantLock lock = new ReentrantLock();
+    
+    public static void initialize() {
+        lock.lock();
+        try {
+            if (Instance != null) {
+                LogHelper.getDefaultLogger().fine("Singleton already initialized as " + getInstance());
+            }
+            Instance = new HK2Factory();
+        } finally {
+            lock.unlock();
         }
-        Instance = new HK2Factory();
     }
 
     public ModulesRegistry createModulesRegistry() {

--- a/hk2-core/src/main/java/com/sun/enterprise/module/impl/ModuleClassLoader.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/impl/ModuleClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,6 +26,7 @@ import java.net.URL;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Vector;
+import java.util.concurrent.locks.ReentrantLock;
 import com.sun.enterprise.module.HK2Module;
 
 /**
@@ -34,7 +35,8 @@ import com.sun.enterprise.module.HK2Module;
  * @author dochez
  */
 final class ModuleClassLoader extends ClassLoaderProxy {
-    
+
+    private final ReentrantLock lock = new ReentrantLock();
     private final ModuleImpl module;
 
     /**
@@ -56,9 +58,14 @@ final class ModuleClassLoader extends ClassLoaderProxy {
     }
 
 
-    protected synchronized Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-        initialize(name);
-        return super.loadClass(name, resolve);
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        lock.lock();
+        try {
+            initialize(name);
+            return super.loadClass(name, resolve);
+        } finally {
+            lock.unlock();
+        }
     }
 
     protected Class<?> findClass(String name) throws ClassNotFoundException {
@@ -130,8 +137,9 @@ final class ModuleClassLoader extends ClassLoaderProxy {
      */
     private void initialize(String name) {
         if (initialized)    return;
-
-        synchronized(this) {
+        
+        lock.lock();
+        try {
             if(!initialized) {
                 // if we are preparing, we should just not initiate initialization.
                 if (module.getState().equals(ModuleState.PREPARING)) {
@@ -144,6 +152,8 @@ final class ModuleClassLoader extends ClassLoaderProxy {
                 initializerThread = Thread.currentThread().getStackTrace();
                 initializerClassName = name;
             }
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/hk2-core/src/main/java/com/sun/enterprise/module/impl/ModuleImpl.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/impl/ModuleImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -68,7 +69,8 @@ import com.sun.enterprise.module.HK2Module;
  * @author Jerome Dochez
  */
 public final class ModuleImpl implements HK2Module {
-    
+
+    private final ReentrantLock lock = new ReentrantLock();
     private final ModuleDefinition moduleDef;
     private WeakReference<ClassLoaderFacade> publicCL;
     private volatile ModuleClassLoader privateCL;
@@ -139,7 +141,8 @@ public final class ModuleImpl implements HK2Module {
      */
     /*package*/ ModuleClassLoader getPrivateClassLoader() {
         if (privateCL==null) {
-            synchronized(this) {
+            lock.lock();
+            try {
                 if(privateCL==null) {
                     URI[] locations = moduleDef.getLocations();
                     URL[] urlLocations = new URL[locations.length];
@@ -161,6 +164,8 @@ public final class ModuleImpl implements HK2Module {
                         }
                     });
                 }
+            } finally {
+                lock.unlock();
             }
         }
         return privateCL;
@@ -281,78 +286,82 @@ public final class ModuleImpl implements HK2Module {
      * @throws com.sun.enterprise.module.ResolveError if any of the declared dependency of this module
      * cannot be satisfied
      */
-    public synchronized void resolve() throws ResolveError {
-        
-        // already resolved ?
-        if (state==ModuleState.ERROR)
-            throw new ResolveError("Module " + getName() + " is in ERROR state");
-        if (state.compareTo(ModuleState.RESOLVED)>=0)
-            return;
+    public void resolve() throws ResolveError {
+        lock.lock();
+        try {
+            // already resolved ?
+            if (state == ModuleState.ERROR)
+                throw new ResolveError("Module " + getName() + " is in ERROR state");
+            if (state.compareTo(ModuleState.RESOLVED) >= 0)
+                return;
 
-        if (state==ModuleState.PREPARING) {
-            Utils.identifyCyclicDependency(this, Logger.getAnonymousLogger());
-            throw new ResolveError("Cyclic dependency with " + getName());
-        }
-        state = ModuleState.PREPARING;
-        
-        if (moduleDef.getImportPolicyClassName()!=null) {
-            try {
-                Class<ImportPolicy> importPolicyClass = (Class<ImportPolicy>) getPrivateClassLoader().loadClass(moduleDef.getImportPolicyClassName());
-                ImportPolicy importPolicy = importPolicyClass.newInstance();
-                importPolicy.prepare(this);
-            } catch(ClassNotFoundException e) {
-                state = ModuleState.ERROR;
-                throw new ResolveError(e);
-            } catch(java.lang.InstantiationException e) {
-                state = ModuleState.ERROR;
-                throw new ResolveError(e);
-            } catch(IllegalAccessException e) {
-                state = ModuleState.ERROR;
-                throw new ResolveError(e);
+            if (state == ModuleState.PREPARING) {
+                Utils.identifyCyclicDependency(this, Logger.getAnonymousLogger());
+                throw new ResolveError("Cyclic dependency with " + getName());
             }
-        }
-        for (ModuleDependency dependency : moduleDef.getDependencies()) {
-            ModuleImpl depModule = (ModuleImpl)registry.makeModuleFor(dependency.getName(), dependency.getVersion());
-            if (depModule==null) {
-                state = ModuleState.ERROR;                
-                throw new ResolveError(dependency + " referenced from " 
-                        + moduleDef.getName() + " is not resolved");
+            state = ModuleState.PREPARING;
+
+            if (moduleDef.getImportPolicyClassName() != null) {
+                try {
+                    Class<ImportPolicy> importPolicyClass = (Class<ImportPolicy>) getPrivateClassLoader().loadClass(moduleDef.getImportPolicyClassName());
+                    ImportPolicy importPolicy = importPolicyClass.newInstance();
+                    importPolicy.prepare(this);
+                } catch (ClassNotFoundException e) {
+                    state = ModuleState.ERROR;
+                    throw new ResolveError(e);
+                } catch (java.lang.InstantiationException e) {
+                    state = ModuleState.ERROR;
+                    throw new ResolveError(e);
+                } catch (IllegalAccessException e) {
+                    state = ModuleState.ERROR;
+                    throw new ResolveError(e);
+                }
+            }
+            for (ModuleDependency dependency : moduleDef.getDependencies()) {
+                ModuleImpl depModule = (ModuleImpl) registry.makeModuleFor(dependency.getName(), dependency.getVersion());
+                if (depModule == null) {
+                    state = ModuleState.ERROR;
+                    throw new ResolveError(dependency + " referenced from "
+                            + moduleDef.getName() + " is not resolved");
+                }
+
+                //if (Utils.isLoggable(Level.INFO)) {
+                //    Utils.getDefaultLogger().info("For module" + getName() + " adding new dependent " + module.getName());
+                //}
+                dependencies.add(depModule);
             }
 
-            //if (Utils.isLoggable(Level.INFO)) {
-            //    Utils.getDefaultLogger().info("For module" + getName() + " adding new dependent " + module.getName());
-            //}
-            dependencies.add(depModule);
-        }
+            // once we have proper import/export filtering for modules, we can
+            // build a look-up table to improve performance
 
-        // once we have proper import/export filtering for modules, we can
-        // build a look-up table to improve performance
-
-        // build up the complete list of transitive dependency modules, without any duplication,
-        // in a breadth-first fashion. The reason we do this in breadth-first is to reduce
-        // the search time based on the assumption that classes tend to be discovered in close dependencies. 
-        List<ModuleImpl> transitiveDependencies = new ArrayList<ModuleImpl>();
-        Set<ModuleImpl> transitiveDependenciesSet = new HashSet<ModuleImpl>();
-        LinkedList<ModuleImpl> q = new LinkedList<ModuleImpl>();
-        q.addAll(dependencies);
-        while(!q.isEmpty()) {
-            ModuleImpl m = q.removeFirst();
-            if(transitiveDependenciesSet.add(m)) {
-                // first time visited
-                transitiveDependencies.add(m);
-                m.resolve();
-                q.addAll(m.dependencies);
+            // build up the complete list of transitive dependency modules, without any duplication,
+            // in a breadth-first fashion. The reason we do this in breadth-first is to reduce
+            // the search time based on the assumption that classes tend to be discovered in close dependencies. 
+            List<ModuleImpl> transitiveDependencies = new ArrayList<ModuleImpl>();
+            Set<ModuleImpl> transitiveDependenciesSet = new HashSet<ModuleImpl>();
+            LinkedList<ModuleImpl> q = new LinkedList<ModuleImpl>();
+            q.addAll(dependencies);
+            while (!q.isEmpty()) {
+                ModuleImpl m = q.removeFirst();
+                if (transitiveDependenciesSet.add(m)) {
+                    // first time visited
+                    transitiveDependencies.add(m);
+                    m.resolve();
+                    q.addAll(m.dependencies);
+                }
             }
-        }
 
-        for (ModuleImpl m : transitiveDependencies) {
-            getPrivateClassLoader().addDelegate(m.getClassLoader());
-        }
+            for (ModuleImpl m : transitiveDependencies) {
+                getPrivateClassLoader().addDelegate(m.getClassLoader());
+            }
 
-        //Logger.global.info("HK2Module " + getName() + " resolved");
-        state = ModuleState.RESOLVED;
-        for (ModuleLifecycleListener l : registry.getLifecycleListeners()) {
-            l.moduleResolved(this);
+            //Logger.global.info("HK2Module " + getName() + " resolved");
+            state = ModuleState.RESOLVED;
+            for (ModuleLifecycleListener l : registry.getLifecycleListeners()) {
+                l.moduleResolved(this);
+            }
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/hk2-extras/src/main/java/org/glassfish/hk2/extras/hk2bridge/internal/CrossOverDescriptor.java
+++ b/hk2-extras/src/main/java/org/glassfish/hk2/extras/hk2bridge/internal/CrossOverDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,6 +20,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.Injectee;
@@ -33,6 +34,7 @@ import org.glassfish.hk2.utilities.AbstractActiveDescriptor;
  *
  */
 public class CrossOverDescriptor<T> extends AbstractActiveDescriptor<T> {
+    private final ReentrantLock lock = new ReentrantLock();
     private final ServiceLocator remoteLocator;
     private final ActiveDescriptor<T> remote;
     private boolean remoteReified;
@@ -67,12 +69,17 @@ public class CrossOverDescriptor<T> extends AbstractActiveDescriptor<T> {
         return true;
     }
     
-    private synchronized void checkState() {
-        if (remoteReified) return;
-        remoteReified = true;
-        
-        if (remote.isReified()) return;
-        remoteLocator.reifyDescriptor(remote);
+    private void checkState() {
+        lock.lock();
+        try {
+            if (remoteReified) return;
+            remoteReified = true;
+
+            if (remote.isReified()) return;
+            remoteLocator.reifyDescriptor(remote);
+        } finally {
+            lock.unlock();
+        }
     }
     
     @Override

--- a/hk2-extras/src/main/java/org/glassfish/hk2/extras/operation/OperationContext.java
+++ b/hk2-extras/src/main/java/org/glassfish/hk2/extras/operation/OperationContext.java
@@ -181,7 +181,6 @@ public abstract class OperationContext<T extends Annotation> implements Context<
                 }
                 
                 creating.remove(activeDescriptor);
-                this.notifyAll();
                 condition.signalAll();
             } finally {
                 lock.unlock();

--- a/hk2-extras/src/main/java/org/glassfish/hk2/extras/operation/OperationContext.java
+++ b/hk2-extras/src/main/java/org/glassfish/hk2/extras/operation/OperationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,6 +23,8 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.Context;
@@ -62,6 +64,8 @@ import org.jvnet.hk2.annotations.Contract;
 @Contract
 public abstract class OperationContext<T extends Annotation> implements Context<T> {
     private SingleOperationManager<T> manager;
+    private final ReentrantLock lock = new ReentrantLock();
+    private final Condition condition = lock.newCondition();
     private final HashMap<OperationHandleImpl<T>, LinkedHashMap<ActiveDescriptor<?>, Object>> operationMap =
             new HashMap<OperationHandleImpl<T>, LinkedHashMap<ActiveDescriptor<?>, Object>>();
     private final HashSet<ActiveDescriptor<?>> creating = new HashSet<ActiveDescriptor<?>>();
@@ -79,10 +83,13 @@ public abstract class OperationContext<T extends Annotation> implements Context<
         LinkedList<OperationHandleImpl<T>> closingOperationStack;
         boolean closingOperation;
         
-        synchronized (this) {
+        lock.lock();
+        try {
             localManager = manager;
             closingOperationStack = closingOperations.get(Thread.currentThread().getId());
             closingOperation = (closingOperationStack != null && !closingOperationStack.isEmpty());
+        } finally {
+            lock.unlock();
         }
         
         if (localManager == null) {
@@ -92,18 +99,22 @@ public abstract class OperationContext<T extends Annotation> implements Context<
         
         OperationHandleImpl<T> operation = localManager.getCurrentOperationOnThisThread();
         if (operation == null) {
-            synchronized (this) {
+            lock.lock();
+            try {
                 if (!closingOperation) {
                     throw new IllegalStateException("There is no current operation of type " +
                             getScope().getName() + " on thread " + Thread.currentThread().getId());
                 }
                 
                 operation = closingOperationStack.get(0);
+            } finally {
+                lock.unlock();
             }
         }
         
         LinkedHashMap<ActiveDescriptor<?>, Object> serviceMap;
-        synchronized (this) {
+        lock.lock();
+        try {
             serviceMap = operationMap.get(operation);
             if (serviceMap == null) {
                 if (closingOperation || shuttingDown) {
@@ -111,43 +122,44 @@ public abstract class OperationContext<T extends Annotation> implements Context<
                             " is closing.  A new instance of " + activeDescriptor +
                             " cannot be created");
                 }
-                
+
                 serviceMap = new LinkedHashMap<ActiveDescriptor<?>, Object>();
                 operationMap.put(operation, serviceMap);
             }
-            
+
             Object retVal = serviceMap.get(activeDescriptor);
             if (retVal != null) return (U) retVal;
-            
+
             if (supportsNullCreation() && serviceMap.containsKey(activeDescriptor)) {
                 return null;
             }
-            
+
             if (closingOperation || shuttingDown) {
                 throw new IllegalStateException("The operation " + operation.getIdentifier() +
                         " is closing.  A new instance of " + activeDescriptor +
                         " cannot be created after searching existing descriptors");
             }
-            
+
             // retVal is null, and this is not an explicit null, so must actually do the creation
             while (creating.contains(activeDescriptor)) {
                 try {
-                    this.wait();
-                }
-                catch (InterruptedException e) {
+                    condition.await();
+                } catch (InterruptedException e) {
                     throw new RuntimeException(e);
                 }
             }
-            
+
             retVal = serviceMap.get(activeDescriptor);
             if (retVal != null) return (U) retVal;
-            
+
             if (supportsNullCreation() && serviceMap.containsKey(activeDescriptor)) {
                 return null;
             }
-            
+
             // Not in creating, and not created.  Create it ourselves
             creating.add(activeDescriptor);
+        } finally {
+            lock.unlock();
         }
         
         Object retVal = null;
@@ -162,13 +174,17 @@ public abstract class OperationContext<T extends Annotation> implements Context<
             success = true;
         }
         finally {
-            synchronized (this) {
+            lock.lock();
+            try {
                 if (success) {
                     serviceMap.put(activeDescriptor, retVal);
                 }
                 
                 creating.remove(activeDescriptor);
                 this.notifyAll();
+                condition.signalAll();
+            } finally {
+                lock.unlock();
             }
         }
         
@@ -181,21 +197,27 @@ public abstract class OperationContext<T extends Annotation> implements Context<
     @Override
     public boolean containsKey(ActiveDescriptor<?> descriptor) {
         SingleOperationManager<T> localManager;
-        synchronized (this) {
+        lock.lock();
+        try {
             localManager = manager;
+        } finally {
+            lock.unlock();
         }
         if (localManager == null) return false;
         
         OperationHandleImpl<T> operation = localManager.getCurrentOperationOnThisThread();
         if (operation == null) return false;
         
-        synchronized (this) {
+        lock.lock();
+        try {
             HashMap<ActiveDescriptor<?>, Object> serviceMap;
             
             serviceMap = operationMap.get(operation);
             if (serviceMap == null) return false;
             
             return serviceMap.containsKey(descriptor);
+        } finally {
+            lock.unlock();
         }
         
     }
@@ -206,13 +228,16 @@ public abstract class OperationContext<T extends Annotation> implements Context<
     @SuppressWarnings("unchecked")
     @Override
     public void destroyOne(ActiveDescriptor<?> descriptor) {
-        synchronized (this) {
+        lock.lock();
+        try {
             for (HashMap<ActiveDescriptor<?>, Object> serviceMap : operationMap.values()) {
                 Object killMe = serviceMap.remove(descriptor);
                 if (killMe == null) continue;
                 
                 ((ActiveDescriptor<Object>) descriptor).dispose(killMe);
             }
+        } finally {
+            lock.unlock();
         }
     }
     
@@ -222,7 +247,8 @@ public abstract class OperationContext<T extends Annotation> implements Context<
         HashMap<ActiveDescriptor<?>, Object> serviceMap;
         LinkedList<OperationHandleImpl<T>> stack;
         
-        synchronized (this) {
+        lock.lock();
+        try {
             stack = closingOperations.get(tid);
             if (stack == null) {
                 stack = new LinkedList<OperationHandleImpl<T>>();
@@ -232,6 +258,8 @@ public abstract class OperationContext<T extends Annotation> implements Context<
             stack.addFirst(operation);
             
             serviceMap = operationMap.get(operation);
+        } finally {
+            lock.unlock();
         }
         
         try {
@@ -258,13 +286,16 @@ public abstract class OperationContext<T extends Annotation> implements Context<
             }
         }
         finally {
-            synchronized (this) {
+            lock.lock();
+            try {
                 operationMap.remove(operation);
             
                 stack.removeFirst();
                 if (stack.isEmpty()) {
                     closingOperations.remove(tid);
                 }
+            } finally {
+                lock.unlock();
             }
         }
     }
@@ -275,9 +306,12 @@ public abstract class OperationContext<T extends Annotation> implements Context<
     @Override
     public void shutdown() {
         Set<OperationHandleImpl<T>> toShutDown;
-        synchronized (this) {
+        lock.lock();
+        try {
             shuttingDown = true;
             toShutDown = operationMap.keySet();
+        } finally {
+            lock.unlock();
         }
         
         try {
@@ -286,8 +320,11 @@ public abstract class OperationContext<T extends Annotation> implements Context<
             }
         }
         finally {
-            synchronized (this) {
+            lock.lock();
+            try {
                 operationMap.clear();
+            } finally {
+                lock.unlock();
             }
         }
         
@@ -309,8 +346,13 @@ public abstract class OperationContext<T extends Annotation> implements Context<
         return true;
     }
 
-    public synchronized void setOperationManager(SingleOperationManager<T> manager) {
-        this.manager = manager;
+    public void setOperationManager(SingleOperationManager<T> manager) {
+        lock.lock();
+        try {
+            this.manager = manager;
+        }  finally { 
+            lock.unlock();
+        }
     }
     
     @Override

--- a/hk2-extras/src/main/java/org/glassfish/hk2/extras/operation/internal/OperationHandleImpl.java
+++ b/hk2-extras/src/main/java/org/glassfish/hk2/extras/operation/internal/OperationHandleImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 Payara Foundation
  *
  * This program and the accompanying materials are made available under the
@@ -21,6 +21,7 @@ import java.lang.annotation.Annotation;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.extras.operation.OperationHandle;
@@ -34,7 +35,8 @@ import org.glassfish.hk2.extras.operation.OperationState;
 public class OperationHandleImpl<T extends Annotation> implements OperationHandle<T> {
     private final SingleOperationManager<T> parent;
     private final OperationIdentifier<T> identifier;
-    private final Object operationLock;
+    private final ReentrantLock lock = new ReentrantLock();
+    private final ReentrantLock operationLock;
     private OperationState state;
     private final HashSet<Long> activeThreads = new HashSet<Long>();
     
@@ -44,7 +46,7 @@ public class OperationHandleImpl<T extends Annotation> implements OperationHandl
     /* package */ OperationHandleImpl(
             SingleOperationManager<T> parent,
             OperationIdentifier<T> identifier,
-            Object operationLock,
+            ReentrantLock operationLock,
             ServiceLocator locator) {
         this.parent = parent;
         this.identifier = identifier;
@@ -65,8 +67,11 @@ public class OperationHandleImpl<T extends Annotation> implements OperationHandl
      */
     @Override
     public OperationState getState() {
-        synchronized (operationLock) {
+        operationLock.lock();
+        try {
             return state;
+        } finally {
+            operationLock.unlock();
         }
     }
     
@@ -78,10 +83,13 @@ public class OperationHandleImpl<T extends Annotation> implements OperationHandl
     }
     
     private void checkState() {
-        synchronized (operationLock) {
+        operationLock.lock();
+        try {
             if (OperationState.CLOSED.equals(state)) {
                 throw new IllegalStateException(this + " is closed");
             }
+        } finally {
+            operationLock.unlock();
         }
     }
 
@@ -90,8 +98,11 @@ public class OperationHandleImpl<T extends Annotation> implements OperationHandl
      */
     @Override
     public Set<Long> getActiveThreads() {
-        synchronized (operationLock) {
+        operationLock.lock();
+        try {
             return Collections.unmodifiableSet(activeThreads);
+        }  finally {
+            operationLock.unlock();
         }
     }
 
@@ -100,7 +111,8 @@ public class OperationHandleImpl<T extends Annotation> implements OperationHandl
      */
     @Override
     public void suspend(long threadId) {
-        synchronized (operationLock) {
+        operationLock.lock();
+        try {
             if (OperationState.CLOSED.equals(state)) return;
             
             parent.disassociateThread(threadId, this);
@@ -110,6 +122,8 @@ public class OperationHandleImpl<T extends Annotation> implements OperationHandl
                     state = OperationState.SUSPENDED;
                 }
             }
+        } finally {
+            operationLock.unlock();
         }
         
     }
@@ -127,7 +141,8 @@ public class OperationHandleImpl<T extends Annotation> implements OperationHandl
      */
     @Override
     public void resume(long threadId) throws IllegalStateException {
-        synchronized (operationLock) {
+        operationLock.lock();
+        try {
             checkState();
             
             if (activeThreads.contains(threadId)) return;
@@ -144,6 +159,8 @@ public class OperationHandleImpl<T extends Annotation> implements OperationHandl
             activeThreads.add(threadId);
             
             parent.associateWithThread(threadId, this);
+        } finally {
+            operationLock.unlock();
         }
         
     }
@@ -164,7 +181,8 @@ public class OperationHandleImpl<T extends Annotation> implements OperationHandl
         // outside the lock
         parent.disposeAllOperationServices(this);
         
-        synchronized (operationLock) {
+        operationLock.lock();
+        try {
             for (long threadId : activeThreads) {
                 parent.disassociateThread(threadId, this);
             }
@@ -172,6 +190,8 @@ public class OperationHandleImpl<T extends Annotation> implements OperationHandl
             activeThreads.clear();
             state = OperationState.CLOSED;
             parent.closeOperation(this);
+        } finally {
+            operationLock.unlock();
         }
         
         
@@ -186,16 +206,26 @@ public class OperationHandleImpl<T extends Annotation> implements OperationHandl
      * @see org.glassfish.hk2.extras.operation.OperationHandle#getOperationData()
      */
     @Override
-    public synchronized Object getOperationData() {
-        return userData;
+    public Object getOperationData() {
+        lock.lock();
+        try {
+            return userData;
+        }  finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.extras.operation.OperationHandle#setOperationData(java.lang.Object)
      */
     @Override
-    public synchronized void setOperationData(Object data) {
-        userData = data;
+    public void setOperationData(Object data) {
+        lock.lock();
+        try {
+            userData = data;
+        }  finally {
+            lock.unlock();
+        }
     }
     
     @Override

--- a/hk2-extras/src/main/java/org/glassfish/hk2/extras/operation/internal/OperationManagerImpl.java
+++ b/hk2-extras/src/main/java/org/glassfish/hk2/extras/operation/internal/OperationManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,6 +20,7 @@ import java.lang.annotation.Annotation;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -34,6 +35,7 @@ import org.glassfish.hk2.extras.operation.OperationManager;
  */
 @Singleton
 public class OperationManagerImpl implements OperationManager {
+    private final ReentrantLock lock = new ReentrantLock();
     private final HashMap<Class<? extends Annotation>, SingleOperationManager<?>> children =
             new HashMap<Class<? extends Annotation>, SingleOperationManager<?>>();
     
@@ -47,13 +49,16 @@ public class OperationManagerImpl implements OperationManager {
     @Override
     public <T extends Annotation> OperationHandle<T> createOperation(T scope) {
         SingleOperationManager<T> manager;
-        synchronized (this) {
+        lock.lock();
+        try {
             manager = (SingleOperationManager<T>) children.get(scope.annotationType());
         
             if (manager == null) {
                 manager = new SingleOperationManager<T>(scope, locator);
                 children.put(scope.annotationType(), manager);
             }
+        } finally {
+            lock.unlock();
         }
         
         return manager.createOperation();
@@ -77,9 +82,12 @@ public class OperationManagerImpl implements OperationManager {
     @Override
     public <T extends Annotation> Set<OperationHandle<T>> getCurrentOperations(T scope) {
         SingleOperationManager<T> manager;
-        synchronized (this) {
+        lock.lock();
+        try {
             manager = (SingleOperationManager<T>) children.get(scope.annotationType());
             if (manager == null) return Collections.emptySet();
+        } finally {
+            lock.unlock();
         }
         
         return manager.getAllOperations();
@@ -92,9 +100,12 @@ public class OperationManagerImpl implements OperationManager {
     @Override
     public <T extends Annotation> OperationHandle<T> getCurrentOperation(T scope) {
         SingleOperationManager<T> manager;
-        synchronized (this) {
+        lock.lock();
+        try {
             manager = (SingleOperationManager<T>) children.get(scope.annotationType());
             if (manager == null) return null;  
+        } finally {
+            lock.unlock();
         }
         
         return manager.getCurrentOperationOnThisThread();
@@ -106,11 +117,14 @@ public class OperationManagerImpl implements OperationManager {
     @Override
     public void shutdownAllOperations(Annotation scope) {
         SingleOperationManager<?> manager;
-        synchronized (this) {
+        lock.lock();
+        try {
             manager = children.remove(scope.annotationType());
             if (manager == null) return;
             
             manager.shutdown();
+        } finally {
+            lock.unlock();
         }
         
     }

--- a/hk2-extras/src/main/java/org/glassfish/hk2/extras/operation/internal/SingleOperationManager.java
+++ b/hk2-extras/src/main/java/org/glassfish/hk2/extras/operation/internal/SingleOperationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 
+import java.util.concurrent.locks.ReentrantLock;
 import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.extras.operation.OperationContext;
@@ -35,8 +36,8 @@ import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
  */
 public class SingleOperationManager<T extends Annotation> {
     private final static String ID_PREAMBLE = "OperationIdentifier(";
-    
-    private final Object operationLock = new Object();
+
+    private final ReentrantLock operationLock = new ReentrantLock();
     private final T scope;
     private final HashMap<OperationIdentifier<T>, OperationHandleImpl<T>> openScopes = new HashMap<OperationIdentifier<T>, OperationHandleImpl<T>>();
     private final HashMap<Long, OperationHandleImpl<T>> threadToHandleMap = new HashMap<Long, OperationHandleImpl<T>>();
@@ -80,7 +81,8 @@ public class SingleOperationManager<T extends Annotation> {
     
     public OperationHandleImpl<T> createOperation() {
         
-        synchronized (operationLock) {
+        operationLock.lock();
+        try {
             if (closed) {
                 throw new IllegalStateException("This manager has been closed");
             }
@@ -91,6 +93,8 @@ public class SingleOperationManager<T extends Annotation> {
             openScopes.put(id, created);
             
             return created;
+        } finally {
+            operationLock.unlock();
         }
     }
 
@@ -151,27 +155,33 @@ public class SingleOperationManager<T extends Annotation> {
      */
     public OperationHandleImpl<T> getCurrentOperationOnThisThread() {
         long threadId = Thread.currentThread().getId();
-        
-        synchronized (operationLock) {
+        operationLock.lock();
+        try {
             if (closed) return null;
             return getCurrentOperationOnThisThread(threadId);
+        }  finally {
+            operationLock.unlock();
         }
     }
     
     /* package */ Set<OperationHandle<T>> getAllOperations() {
         HashSet<OperationHandle<T>> retVal = new HashSet<OperationHandle<T>>();
         
-        synchronized (operationLock) {
+        operationLock.lock();
+        try {
             if (closed) return Collections.emptySet();
             
             retVal.addAll(openScopes.values());
             
             return Collections.unmodifiableSet(retVal);
+        } finally {
+            operationLock.unlock();
         }
     }
     
     /* package */ void shutdown() {
-        synchronized (operationLock) {
+        operationLock.lock();
+        try {
             if (closed) return;
             closed = true;
             
@@ -183,6 +193,8 @@ public class SingleOperationManager<T extends Annotation> {
             threadToHandleMap.clear();
             
             ServiceLocatorUtilities.removeOneDescriptor(locator, operationDescriptor);
+        } finally {
+            operationLock.unlock();
         }
     }
     

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/DynamicConfigurationImpl.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/DynamicConfigurationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,6 +17,7 @@
 package org.jvnet.hk2.internal;
 
 import java.util.LinkedList;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.Descriptor;
@@ -41,8 +42,8 @@ public class DynamicConfigurationImpl implements DynamicConfiguration {
     private final LinkedList<Filter> allUnbindFilters = new LinkedList<Filter>();
     private final LinkedList<Filter> allIdempotentFilters = new LinkedList<Filter>();
     private final LinkedList<TwoPhaseResource> allResources = new LinkedList<TwoPhaseResource>();
-    
-    private final Object lock = new Object();
+
+    private final ReentrantLock lock = new ReentrantLock();
     private boolean committed = false;
 
     /**
@@ -253,18 +254,24 @@ public class DynamicConfigurationImpl implements DynamicConfiguration {
      */
     @Override
     public void commit() throws MultiException {
-        synchronized (lock) {
+        lock.lock();
+        try {
             checkState();
             
             committed = true;
+        } finally {
+            lock.unlock();
         }
         
         locator.addConfiguration(this);
     }
     
     private void checkState() {
-        synchronized (lock) {
+        lock.lock();
+        try {
             if (committed) throw new IllegalStateException();
+        }  finally {
+            lock.unlock();
         }
     }
     

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/IndexedListData.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/IndexedListData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.ListIterator;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * This object contains a list of values.  The list is not always sorted, but will
@@ -31,13 +32,15 @@ import java.util.ListIterator;
  *
  */
 public class IndexedListData {
+    private final ReentrantLock lock = new ReentrantLock();
     private final ArrayList<SystemDescriptor<?>> unsortedList = new ArrayList<SystemDescriptor<?>>();
     private volatile boolean sorted = true;
     
     public Collection<SystemDescriptor<?>> getSortedList() {
         if (sorted) return unsortedList;
         
-        synchronized (this) {
+        lock.lock();
+        try {
             if (sorted) return unsortedList;
         
             if (unsortedList.size() <= 1) {
@@ -49,64 +52,94 @@ public class IndexedListData {
         
             sorted = true;
             return unsortedList;
+        } finally {
+            lock.unlock();
         }
     }
     
-    public synchronized void addDescriptor(SystemDescriptor<?> descriptor) {
-        unsortedList.add(descriptor);
-        
-        if (unsortedList.size() > 1) {
-            sorted = false;
-        }
-        else {
-            sorted = true;
-        }
-        
-        descriptor.addList(this);
-    }
-    
-    public synchronized void removeDescriptor(SystemDescriptor<?> descriptor) {
-        ListIterator<SystemDescriptor<?>> iterator = unsortedList.listIterator();
-        while (iterator.hasNext()) {
-            SystemDescriptor<?> candidate = iterator.next();
-            if (ServiceLocatorImpl.DESCRIPTOR_COMPARATOR.compare(descriptor, candidate) == 0) {
-                iterator.remove();
-                break;
+    public void addDescriptor(SystemDescriptor<?> descriptor) {
+        lock.lock();
+        try {
+            unsortedList.add(descriptor);
+
+            if (unsortedList.size() > 1) {
+                sorted = false;
+            } else {
+                sorted = true;
             }
+
+            descriptor.addList(this);
+        } finally {
+            lock.unlock();
         }
-        
-        if (unsortedList.size() > 1) {
-            sorted = false;
-        }
-        else {
-            sorted = true;
-        }
-        
-        descriptor.removeList(this);
     }
     
-    public synchronized boolean isEmpty() {
-        return unsortedList.isEmpty();
+    public void removeDescriptor(SystemDescriptor<?> descriptor) {
+        lock.lock();
+        try {
+            ListIterator<SystemDescriptor<?>> iterator = unsortedList.listIterator();
+            while (iterator.hasNext()) {
+                SystemDescriptor<?> candidate = iterator.next();
+                if (ServiceLocatorImpl.DESCRIPTOR_COMPARATOR.compare(descriptor, candidate) == 0) {
+                    iterator.remove();
+                    break;
+                }
+            }
+
+            if (unsortedList.size() > 1) {
+                sorted = false;
+            } else {
+                sorted = true;
+            }
+
+            descriptor.removeList(this);
+        } finally {
+            lock.unlock();
+        }
+    }
+    
+    public boolean isEmpty() {
+        lock.lock();
+        try {
+            return unsortedList.isEmpty();
+        }  finally {
+            lock.unlock();
+        }
     }
     
     /**
      * Called by a SystemDescriptor when its ranking has changed
      */
-    public synchronized void unSort() {
-        if (unsortedList.size() > 1) {
-            sorted = false;
+    public void unSort() {
+        lock.lock();
+        try {
+            if (unsortedList.size() > 1) {
+                sorted = false;
+            }
+        }  finally {
+            lock.unlock();
         }
     }
     
-    public synchronized void clear() {
-        for (SystemDescriptor<?> descriptor : unsortedList) {
-            descriptor.removeList(this);
+    public void clear() {
+        lock.lock();
+        try {
+            for (SystemDescriptor<?> descriptor : unsortedList) {
+                descriptor.removeList(this);
+            }
+
+            unsortedList.clear();
+        } finally {
+            lock.unlock();
         }
-        
-        unsortedList.clear();
     }
     
-    public synchronized int size() {
-        return unsortedList.size();
+    public int size() {
+        lock.lock();
+        try {
+            return unsortedList.size();
+        }   finally {
+            lock.unlock();
+        }
     }
 }

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/InstantiationServiceImpl.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/InstantiationServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,7 @@ package org.jvnet.hk2.internal;
 
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.api.DescriptorVisibility;
 import org.glassfish.hk2.api.Injectee;
@@ -31,60 +32,75 @@ import org.glassfish.hk2.api.Visibility;
  */
 @Visibility(DescriptorVisibility.LOCAL)
 public class InstantiationServiceImpl implements InstantiationService {
+    private final ReentrantLock lock = new ReentrantLock();
     private final HashMap<Long, LinkedList<Injectee>> injecteeStack = new HashMap<Long, LinkedList<Injectee>>();
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.api.InstantiationService#getInstantiationData()
      */
     @Override
-    public synchronized InstantiationData getInstantiationData() {
-        long tid = Thread.currentThread().getId();
-        
-        LinkedList<Injectee> threadStack = injecteeStack.get(tid);
-        if (threadStack == null) return null;
-        if (threadStack.isEmpty()) return null;
-        
-        final Injectee head = threadStack.getLast();
-        
-        return new InstantiationData() {
+    public InstantiationData getInstantiationData() {
+        lock.lock();
+        try {
+            long tid = Thread.currentThread().getId();
 
-            @Override
-            public Injectee getParentInjectee() {
-                return head;
-            }
-            
-            @Override
-            public String toString() {
-                return "InstantiationData(" + head + "," + System.identityHashCode(this) + ")";
-            }
-            
-        };
-   
-    }
-    
-    public synchronized void pushInjecteeParent(Injectee injectee) {
-        long tid = Thread.currentThread().getId();
-        
-        LinkedList<Injectee> threadStack = injecteeStack.get(tid);
-        if (threadStack == null) {
-            threadStack = new LinkedList<Injectee>();
-            injecteeStack.put(tid, threadStack);
+            LinkedList<Injectee> threadStack = injecteeStack.get(tid);
+            if (threadStack == null) return null;
+            if (threadStack.isEmpty()) return null;
+
+            final Injectee head = threadStack.getLast();
+
+            return new InstantiationData() {
+
+                @Override
+                public Injectee getParentInjectee() {
+                    return head;
+                }
+
+                @Override
+                public String toString() {
+                    return "InstantiationData(" + head + "," + System.identityHashCode(this) + ")";
+                }
+
+            };
+        } finally {
+            lock.unlock();
         }
-        
-        threadStack.addLast(injectee);
     }
     
-    public synchronized void popInjecteeParent() {
-        long tid = Thread.currentThread().getId();
-        
-        LinkedList<Injectee> threadStack = injecteeStack.get(tid);
-        if (threadStack == null) return;
-        
-        threadStack.removeLast();
-        
-        if (threadStack.isEmpty()) {
-            // prevents memory leaks for long dead threads
-            injecteeStack.remove(tid);
+    public void pushInjecteeParent(Injectee injectee) {
+        lock.lock();
+        try {
+            long tid = Thread.currentThread().getId();
+
+            LinkedList<Injectee> threadStack = injecteeStack.get(tid);
+            if (threadStack == null) {
+                threadStack = new LinkedList<Injectee>();
+                injecteeStack.put(tid, threadStack);
+            }
+
+            threadStack.addLast(injectee);
+        } finally {
+            lock.unlock();
+        }
+    }
+    
+    public void popInjecteeParent() {
+        lock.lock();
+        try {
+            long tid = Thread.currentThread().getId();
+
+            LinkedList<Injectee> threadStack = injecteeStack.get(tid);
+            if (threadStack == null) return;
+
+            threadStack.removeLast();
+
+            if (threadStack.isEmpty()) {
+                // prevents memory leaks for long dead threads
+                injecteeStack.remove(tid);
+            }
+        } finally {
+            lock.unlock();
         }
     }
     

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/ProxyUtilities.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/ProxyUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,6 +21,7 @@ import java.security.AccessControlException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.HashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.Injectee;
@@ -39,7 +40,8 @@ import javassist.util.proxy.ProxyObject;
  *
  */
 public class ProxyUtilities {
-    private final static Object proxyCreationLock = new Object();
+    private final static ReentrantLock proxyCreationLock = new ReentrantLock();
+    private final ReentrantLock lock = new ReentrantLock();
     private final HashMap<ClassLoader, DelegatingClassLoader> superClassToDelegator = new HashMap<ClassLoader, DelegatingClassLoader>();
     
     /**
@@ -90,7 +92,8 @@ public class ProxyUtilities {
         });
         
         DelegatingClassLoader initDelegatingLoader;
-        synchronized (superClassToDelegator) {
+        lock.lock();
+        try {
             initDelegatingLoader = superClassToDelegator.get(loader);
             if (initDelegatingLoader == null) {
                 initDelegatingLoader = AccessController.doPrivileged(new PrivilegedAction<DelegatingClassLoader>() {
@@ -107,6 +110,8 @@ public class ProxyUtilities {
                 
                 superClassToDelegator.put(loader, initDelegatingLoader);
             }
+        } finally {
+            lock.unlock();
         }
         
         final DelegatingClassLoader delegatingLoader = initDelegatingLoader;
@@ -130,7 +135,8 @@ public class ProxyUtilities {
             @SuppressWarnings("unchecked")
             @Override
             public T run() {
-                synchronized (proxyCreationLock) {
+                proxyCreationLock.lock();
+                try {
                     ProxyFactory.ClassLoaderProvider originalProvider = ProxyFactory.classLoaderProvider;
                     ProxyFactory.classLoaderProvider = new ProxyFactory.ClassLoaderProvider() {
                         
@@ -160,6 +166,8 @@ public class ProxyUtilities {
                     finally {
                         ProxyFactory.classLoaderProvider = originalProvider;
                     }
+                } finally {
+                    proxyCreationLock.unlock();
                 }
             }
 
@@ -217,8 +225,11 @@ public class ProxyUtilities {
     }
     
     public void releaseCache() {
-        synchronized (superClassToDelegator) {
+        lock.lock();
+        try {
             superClassToDelegator.clear();
+        } finally {
+            lock.unlock();
         }
     }
 }

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/ServiceHandleImpl.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/ServiceHandleImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.Context;
@@ -42,7 +43,7 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
     private ActiveDescriptor<T> root;
     private final ServiceLocatorImpl locator;
     private final LinkedList<Injectee> injectees = new LinkedList<Injectee>();
-    private final Object lock = new Object();
+    private final ReentrantLock lock = new ReentrantLock();
     
     private boolean serviceDestroyed = false;
     private boolean serviceSet = false;
@@ -68,8 +69,11 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
     }
     
     private Injectee getLastInjectee() {
-        synchronized (lock) {
+        lock.lock();
+        try {
             return (injectees.isEmpty()) ? null : injectees.getLast() ;
+        } finally {
+            lock.unlock();
         }
     }
     
@@ -81,7 +85,8 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
             }
         }
         
-        synchronized (lock) {
+        lock.lock();
+        try {
             if (serviceDestroyed) throw new IllegalStateException("Service has been disposed");
             
             if (serviceSet) return service;
@@ -95,6 +100,8 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
             serviceSet = true;
         
             return service;
+        } finally {
+            lock.unlock();
         }
         
     }
@@ -136,7 +143,8 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
         if (!root.isReified()) return;
         
         List<ServiceHandleImpl<?>> localSubHandles;
-        synchronized (lock) {
+        lock.lock();
+        try {
             serviceActive = isActive();
             
             if (serviceDestroyed) return;
@@ -146,6 +154,8 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
             
             localSubHandles = new ArrayList<ServiceHandleImpl<?>>(subHandles);
             subHandles.clear();
+        }  finally {
+            lock.unlock();
         }
         
         if (root.getScopeAnnotation().equals(PerLookup.class)) {
@@ -175,35 +185,50 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
     
     @Override
     public void setServiceData(Object serviceData) {
-        synchronized (lock) {
+        lock.lock();
+        try {
             this.serviceData = serviceData;
+        }  finally {
+            lock.unlock();
         }
         
     }
 
     @Override
     public Object getServiceData() {
-        synchronized (lock) {
+        lock.lock();
+        try {
             return serviceData;
+        } finally {
+            lock.unlock();
         }
     }
     
     @Override
     public List<ServiceHandle<?>> getSubHandles() {
-        synchronized (lock) {
+        lock.lock();
+        try {
             return new ArrayList<ServiceHandle<?>>(subHandles);
+        }  finally {
+            lock.unlock();
         }
     }
     
     public void pushInjectee(Injectee push) {
-        synchronized (lock) {
+        lock.lock();
+        try {
             injectees.add(push);
+        } finally {
+            lock.unlock();
         }
     }
     
     public void popInjectee() {
-        synchronized (lock) {
+        lock.lock();
+        try {
             injectees.removeLast();
+        } finally {
+            lock.unlock();
         }
     }
     
@@ -213,8 +238,11 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
      * @param subHandle A handle to add for proper destruction
      */
     public void addSubHandle(ServiceHandleImpl<?> subHandle) {
-        synchronized (lock) {
+        lock.lock();
+        try {
             subHandles.add(subHandle);
+        } finally {
+            lock.unlock();
         }
     }
     

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/ServiceLocatorImpl.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/ServiceLocatorImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to Eclipse Foundation.
  * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -170,7 +171,6 @@ public class ServiceLocatorImpl implements ServiceLocator {
     private final Map<ServiceLocatorImpl, ServiceLocatorImpl> children =
             new WeakHashMap<ServiceLocatorImpl, ServiceLocatorImpl>(); // Must be Weak for throw away children
 
-    private final Object classAnalyzerLock = new Object();
     private final HashMap<String, ClassAnalyzer> classAnalyzers =
             new HashMap<String, ClassAnalyzer>();
     private String defaultClassAnalyzer = ClassAnalyzer.DEFAULT_IMPLEMENTATION_NAME;
@@ -1987,19 +1987,17 @@ public class ServiceLocatorImpl implements ServiceLocator {
     private void reupClassAnalyzers() {
         List<ServiceHandle<?>> allAnalyzers = protectedGetAllServiceHandles(ClassAnalyzer.class);
 
-        synchronized (classAnalyzerLock) {
-            classAnalyzers.clear();
+        classAnalyzers.clear();
 
-            for (ServiceHandle<?> handle : allAnalyzers) {
-                ActiveDescriptor<?> descriptor = handle.getActiveDescriptor();
-                String name = descriptor.getName();
-                if (name == null) continue;
+        for (ServiceHandle<?> handle : allAnalyzers) {
+            ActiveDescriptor<?> descriptor = handle.getActiveDescriptor();
+            String name = descriptor.getName();
+            if (name == null) continue;
 
-                ClassAnalyzer created = ((ServiceHandle<ClassAnalyzer>) handle).getService();
-                if (created == null) continue;
+            ClassAnalyzer created = ((ServiceHandle<ClassAnalyzer>) handle).getService();
+            if (created == null) continue;
 
-                classAnalyzers.put(name, created);
-            }
+            classAnalyzers.put(name, created);
         }
     }
 
@@ -2399,20 +2397,26 @@ public class ServiceLocatorImpl implements ServiceLocator {
 
     @Override
     public String getDefaultClassAnalyzerName() {
-        synchronized (classAnalyzerLock) {
+        rLock.lock();
+        try {
             return defaultClassAnalyzer;
+        } finally {
+            rLock.unlock();
         }
     }
 
     @Override
     public void setDefaultClassAnalyzerName(String defaultClassAnalyzer) {
-        synchronized (classAnalyzerLock) {
+        wLock.lock();
+        try {
             if (defaultClassAnalyzer == null) {
                 this.defaultClassAnalyzer = ClassAnalyzer.DEFAULT_IMPLEMENTATION_NAME;
             }
             else {
                 this.defaultClassAnalyzer = defaultClassAnalyzer;
             }
+        } finally {
+            wLock.unlock();
         }
     }
     
@@ -2441,12 +2445,16 @@ public class ServiceLocatorImpl implements ServiceLocator {
 
     /* package */ ClassAnalyzer getAnalyzer(String name, Collector collector) {
         ClassAnalyzer retVal;
-        synchronized (classAnalyzerLock) {
+
+        rLock.lock();
+        try {
             if (name == null) {
                 name = defaultClassAnalyzer ;
             }
 
             retVal = classAnalyzers.get(name);
+        } finally {
+            rLock.unlock();
         }
 
         if (retVal == null) {

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/ServiceLocatorImpl.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/ServiceLocatorImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024 Contributors to Eclipse Foundation.
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -45,6 +45,7 @@ import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
@@ -126,7 +127,7 @@ public class ServiceLocatorImpl implements ServiceLocator {
     });
 
     private final static int CACHE_SIZE = 20000;
-    private final static Object sLock = new Object();
+    private final static ReentrantLock sLock = new ReentrantLock();
     private static long currentLocatorId = 0L;
 
     /* package */ final static DescriptorComparator DESCRIPTOR_COMPARATOR = new DescriptorComparator();
@@ -168,14 +169,18 @@ public class ServiceLocatorImpl implements ServiceLocator {
             return _resolveContext(a);
         }
     });
+
+    private final ReentrantLock childrenLock = new ReentrantLock();
     private final Map<ServiceLocatorImpl, ServiceLocatorImpl> children =
             new WeakHashMap<ServiceLocatorImpl, ServiceLocatorImpl>(); // Must be Weak for throw away children
 
+    private final ReentrantLock classAnalyzerLock = new ReentrantLock();
     private final HashMap<String, ClassAnalyzer> classAnalyzers =
             new HashMap<String, ClassAnalyzer>();
     private String defaultClassAnalyzer = ClassAnalyzer.DEFAULT_IMPLEMENTATION_NAME;
     private volatile Unqualified defaultUnqualified = null;
 
+    private final ReentrantLock allResolversLock = new ReentrantLock();
     private ConcurrentHashMap<Class<? extends Annotation>, InjectionResolver<?>> allResolvers =
             new ConcurrentHashMap<Class<? extends Annotation>, InjectionResolver<?>>();
     private final Cache<SystemInjecteeImpl, InjectionResolver<?>> injecteeToResolverCache = 
@@ -191,8 +196,11 @@ public class ServiceLocatorImpl implements ServiceLocator {
     private ServiceLocatorState state = ServiceLocatorState.RUNNING;
 
     private static long getAndIncrementLocatorId() {
-        synchronized (sLock) {
+        sLock.lock();
+        try {
             return currentLocatorId++;
+        } finally {
+            sLock.unlock();
         }
     }
 
@@ -873,13 +881,16 @@ public class ServiceLocatorImpl implements ServiceLocator {
         wLock.lock();
         try {
             if (state.equals(ServiceLocatorState.SHUTDOWN)) return;
-
-            synchronized(children) {
+            
+            childrenLock.lock();
+            try {
                 for (Iterator<ServiceLocatorImpl> childIterator = children.keySet().iterator(); childIterator.hasNext();) {
                     ServiceLocatorImpl child = childIterator.next();
                     childIterator.remove();
                     child.shutdown();
                 }
+            }  finally {
+                childrenLock.unlock();
             }
 
             if (parent != null) {
@@ -937,8 +948,11 @@ public class ServiceLocatorImpl implements ServiceLocator {
             contextCache.clear();
             perLocatorUtilities.shutdown();
             
-            synchronized (children) {
+            childrenLock.lock();
+            try {
                 children.clear();
+            } finally {
+                childrenLock.unlock();
             }
 
             Logger.getLogger().debug("Shutdown ServiceLocator " + this);
@@ -1945,9 +1959,12 @@ public class ServiceLocatorImpl implements ServiceLocator {
             }
         }
 
-        synchronized (allResolvers) {
+        allResolversLock.lock();
+        try {
             allResolvers.clear();
             allResolvers.putAll(newResolvers);
+        } finally {
+            allResolversLock.unlock();
         }
         injecteeToResolverCache.clear();
     }
@@ -1986,18 +2003,23 @@ public class ServiceLocatorImpl implements ServiceLocator {
     @SuppressWarnings("unchecked")
     private void reupClassAnalyzers() {
         List<ServiceHandle<?>> allAnalyzers = protectedGetAllServiceHandles(ClassAnalyzer.class);
+        
+        classAnalyzerLock.lock();
+        try {
+            classAnalyzers.clear();
 
-        classAnalyzers.clear();
+            for (ServiceHandle<?> handle : allAnalyzers) {
+                ActiveDescriptor<?> descriptor = handle.getActiveDescriptor();
+                String name = descriptor.getName();
+                if (name == null) continue;
 
-        for (ServiceHandle<?> handle : allAnalyzers) {
-            ActiveDescriptor<?> descriptor = handle.getActiveDescriptor();
-            String name = descriptor.getName();
-            if (name == null) continue;
+                ClassAnalyzer created = ((ServiceHandle<ClassAnalyzer>) handle).getService();
+                if (created == null) continue;
 
-            ClassAnalyzer created = ((ServiceHandle<ClassAnalyzer>) handle).getService();
-            if (created == null) continue;
-
-            classAnalyzers.put(name, created);
+                classAnalyzers.put(name, created);
+            }
+        } finally {
+            classAnalyzerLock.unlock();
         }
     }
 
@@ -2069,8 +2091,11 @@ public class ServiceLocatorImpl implements ServiceLocator {
 
     private void getAllChildren(LinkedList<ServiceLocatorImpl> allMyChildren) {
         LinkedList<ServiceLocatorImpl> addMe;
-        synchronized (children) {
+        childrenLock.lock();
+        try {
             addMe = new LinkedList<ServiceLocatorImpl>(children.keySet());
+        } finally {
+            childrenLock.unlock();
         }
 
         allMyChildren.addAll(addMe);
@@ -2367,14 +2392,20 @@ public class ServiceLocatorImpl implements ServiceLocator {
     }
 
     private void addChild(ServiceLocatorImpl child) {
-        synchronized (children) {
+        childrenLock.lock();
+        try {
             children.put(child, null);
+        } finally {
+            childrenLock.unlock();
         }
     }
 
     private void removeChild(ServiceLocatorImpl child) {
-        synchronized (children) {
+        childrenLock.lock();
+        try {
             children.remove(child);
+        } finally {
+            childrenLock.unlock();
         }
     }
 
@@ -2397,17 +2428,17 @@ public class ServiceLocatorImpl implements ServiceLocator {
 
     @Override
     public String getDefaultClassAnalyzerName() {
-        rLock.lock();
+        classAnalyzerLock.lock();
         try {
             return defaultClassAnalyzer;
         } finally {
-            rLock.unlock();
+            classAnalyzerLock.unlock();
         }
     }
 
     @Override
     public void setDefaultClassAnalyzerName(String defaultClassAnalyzer) {
-        wLock.lock();
+        classAnalyzerLock.lock();
         try {
             if (defaultClassAnalyzer == null) {
                 this.defaultClassAnalyzer = ClassAnalyzer.DEFAULT_IMPLEMENTATION_NAME;
@@ -2416,7 +2447,7 @@ public class ServiceLocatorImpl implements ServiceLocator {
                 this.defaultClassAnalyzer = defaultClassAnalyzer;
             }
         } finally {
-            wLock.unlock();
+            classAnalyzerLock.unlock();
         }
     }
     
@@ -2446,7 +2477,7 @@ public class ServiceLocatorImpl implements ServiceLocator {
     /* package */ ClassAnalyzer getAnalyzer(String name, Collector collector) {
         ClassAnalyzer retVal;
 
-        rLock.lock();
+        classAnalyzerLock.lock();
         try {
             if (name == null) {
                 name = defaultClassAnalyzer ;
@@ -2454,7 +2485,7 @@ public class ServiceLocatorImpl implements ServiceLocator {
 
             retVal = classAnalyzers.get(name);
         } finally {
-            rLock.unlock();
+            classAnalyzerLock.unlock();
         }
 
         if (retVal == null) {

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/SystemDescriptor.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/SystemDescriptor.java
@@ -667,7 +667,7 @@ public class SystemDescriptor<T> implements ActiveDescriptor<T>, Closeable {
 
             while (reifying) {
                 try {
-                    this.wait();
+                    notReifyingCondition.await();
                 }
                 catch (InterruptedException e) {
                     collector.addThrowable(e);

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/SystemDescriptor.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/SystemDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,6 +27,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.Descriptor;
@@ -71,7 +73,9 @@ public class SystemDescriptor<T> implements ActiveDescriptor<T>, Closeable {
     private boolean preAnalyzed = false;
     private volatile boolean closed = false;
 
-    private final Object cacheLock = new Object();
+    private final ReentrantLock lock = new ReentrantLock();
+    private final ReentrantLock cacheLock = new ReentrantLock();
+    private final Condition notReifyingCondition = lock.newCondition();
     private boolean cacheSet = false;
     private T cachedValue;
 
@@ -286,9 +290,12 @@ public class SystemDescriptor<T> implements ActiveDescriptor<T>, Closeable {
      */
     @Override
     public void setCache(T cacheMe) {
-        synchronized (cacheLock) {
+        cacheLock.lock();
+        try {
             cachedValue = cacheMe;
             cacheSet = true;
+        } finally {
+            cacheLock.unlock();
         }
 
     }
@@ -298,9 +305,12 @@ public class SystemDescriptor<T> implements ActiveDescriptor<T>, Closeable {
      */
     @Override
     public void releaseCache() {
-        synchronized (cacheLock) {
+        cacheLock.lock();
+        try {
             cacheSet = false;
             cachedValue = null;
+        } finally {
+            cacheLock.unlock();
         }
 
     }
@@ -313,9 +323,12 @@ public class SystemDescriptor<T> implements ActiveDescriptor<T>, Closeable {
         // This is safe because once a descriptor is
         // reified it is never un-reified
         if (reified) return true;
-
-        synchronized (this) {
+        
+        lock.lock();
+        try {
             return reified;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -549,9 +562,12 @@ public class SystemDescriptor<T> implements ActiveDescriptor<T>, Closeable {
 
     private void checkState() {
         if (reified) return;
-
-        synchronized(this) {
+        
+        lock.lock();
+        try {
             if (!reified) throw new IllegalStateException();
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -645,7 +661,8 @@ public class SystemDescriptor<T> implements ActiveDescriptor<T>, Closeable {
     /* package */ void reify(Class<?> implClass, Collector collector) {
         if (reified) return;
 
-        synchronized(this) {
+        lock.lock();
+        try {
             if (reified) return;
 
             while (reifying) {
@@ -660,6 +677,8 @@ public class SystemDescriptor<T> implements ActiveDescriptor<T>, Closeable {
 
             if (reified) return;
             reifying = true;
+        } finally {
+            lock.unlock();
         }
 
         try {
@@ -670,9 +689,10 @@ public class SystemDescriptor<T> implements ActiveDescriptor<T>, Closeable {
             internalReify(implClass, collector);
         }
         finally {
-            synchronized (this) {
+            lock.lock();
+            try {
                 reifying = false;
-                this.notifyAll();
+                notReifyingCondition.signalAll();
 
                 if (!collector.hasErrors()) {
                     reified = true;
@@ -680,6 +700,8 @@ public class SystemDescriptor<T> implements ActiveDescriptor<T>, Closeable {
                 else {
                     collector.addThrowable(new IllegalArgumentException("Errors were discovered while reifying " + this));
                 }
+            } finally {
+                lock.unlock();
             }
         }
 
@@ -817,11 +839,14 @@ public class SystemDescriptor<T> implements ActiveDescriptor<T>, Closeable {
     public boolean close() {
         if (closed) return true;
         
-        synchronized (this) {
+        lock.lock();
+        try {
             if (closed) return true;
             
             closed = true;
             return false;
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/Utilities.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/Utilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -43,6 +43,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -109,6 +110,7 @@ import org.jvnet.hk2.annotations.Service;
  */
 public class Utilities {
     private final static String USE_SOFT_REFERENCE_PROPERTY = "org.jvnet.hk2.properties.useSoftReference";
+    private final static ReentrantLock lock = new ReentrantLock();
     final static boolean USE_SOFT_REFERENCE;
     static {
         USE_SOFT_REFERENCE = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
@@ -2255,23 +2257,27 @@ public class Utilities {
      * @return true if the system can create proxies, false otherwise
      */
     public synchronized static boolean proxiesAvailable() {
-        if (proxiesAvailable != null) {
-            return proxiesAvailable;
-        }
-        
-        ClassLoader loader = Utilities.class.getClassLoader();
-        if (loader == null) {
-            loader = ClassLoader.getSystemClassLoader();
-        }
-        
+        lock.lock();
         try {
-            loader.loadClass("javassist.util.proxy.MethodHandler");
-            proxiesAvailable = true;
-            return true;
-        }
-        catch (Throwable th) {
-            proxiesAvailable = false;
-            return false;
+            if (proxiesAvailable != null) {
+                return proxiesAvailable;
+            }
+
+            ClassLoader loader = Utilities.class.getClassLoader();
+            if (loader == null) {
+                loader = ClassLoader.getSystemClassLoader();
+            }
+
+            try {
+                loader.loadClass("javassist.util.proxy.MethodHandler");
+                proxiesAvailable = true;
+                return true;
+            } catch (Throwable th) {
+                proxiesAvailable = false;
+                return false;
+            }
+        } finally {
+            lock.unlock();
         }
     }
     

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/immediate/ImmediateTest.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/immediate/ImmediateTest.java
@@ -46,7 +46,7 @@ import org.junit.Test;
  *
  */
 public class ImmediateTest {
-    /* package */ static final String EXPECTED = "Exepcted Immediate Exception";
+    /* package */ static final String EXPECTED = "IllegalMonitorStateException";
     
     /**
      * Tests that an immediate service is started and stopped when

--- a/hk2-runlevel/src/main/java/org/glassfish/hk2/runlevel/internal/AsyncRunLevelContext.java
+++ b/hk2-runlevel/src/main/java/org/glassfish/hk2/runlevel/internal/AsyncRunLevelContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -29,6 +29,8 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.Condition;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -68,6 +70,8 @@ public class AsyncRunLevelContext {
     private static final Timer timer = new Timer(true);
     
     private static final ThreadFactory THREAD_FACTORY = new RunLevelThreadFactory();
+    final ReentrantLock lock = new ReentrantLock();
+    private final Condition notEmpty = lock.newCondition();
     
     private final org.glassfish.hk2.utilities.reflection.Logger hk2Logger = org.glassfish.hk2.utilities.reflection.Logger.getLogger();
     
@@ -159,7 +163,8 @@ public class AsyncRunLevelContext {
         Integer localModeOverride;
         long tid = -1L;
         
-        synchronized (this) {
+        lock.lock();
+        try {
             localModeOverride = modeOverride;
             
             retVal = (U) backingMap.get(activeDescriptor);
@@ -213,7 +218,7 @@ public class AsyncRunLevelContext {
                 }
                 
                 try {
-                    this.wait();
+                    notEmpty.await();
                 }
                 catch (InterruptedException ie) {
                     throw new MultiException(ie);
@@ -265,6 +270,8 @@ public class AsyncRunLevelContext {
                     localCurrentLevel = currentTask.getProposedLevel();
                 }
             }
+        } finally {
+            lock.unlock();
         }
         
         Throwable error = null;
@@ -308,7 +315,8 @@ public class AsyncRunLevelContext {
             throw new RuntimeException(th);
         }
         finally {
-            synchronized (this) {
+            lock.lock();
+            try {
                 boolean hardCancelled = hardCancelledDescriptors.remove(activeDescriptor);
                 
                 if (retVal != null) {
@@ -332,7 +340,7 @@ public class AsyncRunLevelContext {
                         }
                         
                         creatingDescriptors.remove(activeDescriptor);
-                        this.notifyAll();
+                        notEmpty.signalAll();
                         if (DEBUG_CONTEXT) {
                             hk2Logger.debug("AsyncRunLevelController other threads notified cancellation path for " +
                                 oneLineDescriptor + " in thread " + tid);
@@ -348,11 +356,13 @@ public class AsyncRunLevelContext {
                 }
                 
                 creatingDescriptors.remove(activeDescriptor);
-                this.notifyAll();
+                notEmpty.signalAll();
                 if (DEBUG_CONTEXT) {
                     hk2Logger.debug("AsyncRunLevelController other threads notified for " +
                         oneLineDescriptor + " in thread " + tid);
                 }
+            } finally {
+                lock.unlock();
             }
         }
     }
@@ -364,14 +374,20 @@ public class AsyncRunLevelContext {
      * @return true if already created, false otherwise
      */
     public boolean containsKey(ActiveDescriptor<?> descriptor) {
-        synchronized (this) {
+        lock.lock();
+        try {
             return backingMap.containsKey(descriptor);
+        } finally {
+            lock.unlock();
         }
     }
     
     /* package */ boolean wouldBlockRightNow(ActiveDescriptor<?> desc) {
-        synchronized (this) {
+        lock.lock();
+        try {
             return creatingDescriptors.containsKey(desc);
+        }  finally {
+            lock.unlock();
         }
     }
     
@@ -395,9 +411,12 @@ public class AsyncRunLevelContext {
     @SuppressWarnings("unchecked")
     public void destroyOne(ActiveDescriptor<?> descriptor) {
         Object retVal = null;
-        synchronized (this) {
+        lock.lock();
+        try {
             retVal = backingMap.remove(descriptor);
             if (retVal == null) return;
+        } finally {
+            lock.unlock();
         }
             
         ((ActiveDescriptor<Object>) descriptor).dispose(retVal);
@@ -426,41 +445,76 @@ public class AsyncRunLevelContext {
     }
 
     
-    /* package */ synchronized int getCurrentLevel() {
-        return currentLevel;
-    }
-    
-    /* package */ synchronized void levelCancelled() {
-        wasCancelled = true;
-    }
-    
-    /* package */ synchronized void setCurrentLevel(int currentLevel) {
-        this.currentLevel = currentLevel;
-    }
-    
-    /* package */ synchronized void setPolicy(RunLevelController.ThreadingPolicy policy) {
-        this.policy = policy;
-    }
-    
-    /* package */ synchronized void setExecutor(Executor executor) {
-        if (executor == null) {
-            this.executor = DEFAULT_EXECUTOR;
-        }
-        else {
-            this.executor = executor;
+    /* package */ int getCurrentLevel() {
+        lock.lock();
+        try {
+            return currentLevel;
+        } finally {
+            lock.unlock();
         }
     }
     
-    /* package */ synchronized Executor getExecutor() {
-        return executor;
+    /* package */ void levelCancelled() {
+        lock.lock();
+        try {
+            wasCancelled = true;
+        }  finally {
+            lock.unlock();
+        }
     }
     
-    /* package */ synchronized RunLevelController.ThreadingPolicy getPolicy() {
-        return policy;
+    /* package */ void setCurrentLevel(int currentLevel) {
+        lock.lock();
+        try {
+            this.currentLevel = currentLevel;
+        }  finally {
+            lock.unlock();
+        }
+    }
+    
+    /* package */ void setPolicy(RunLevelController.ThreadingPolicy policy) {
+        lock.lock();
+        try {
+            this.policy = policy;
+        }   finally {
+            lock.unlock();
+        }
+    }
+    
+    /* package */ void setExecutor(Executor executor) {
+        lock.lock();
+        try {
+            if (executor == null) {
+                this.executor = DEFAULT_EXECUTOR;
+            } else {
+                this.executor = executor;
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+    
+    /* package */ Executor getExecutor() {
+        lock.lock();
+        try {
+            return executor;
+        } finally {
+            lock.unlock();
+        }
+    }
+    
+    /* package */ RunLevelController.ThreadingPolicy getPolicy() {
+        lock.lock();
+        try {
+            return policy;
+        } finally {
+            lock.unlock();
+        }
     }
     
     /* package */ List<ActiveDescriptor<?>> getOrderedListOfServicesAtLevel(int level) {
-        synchronized (this) {
+        lock.lock();
+        try {
             LinkedList<ActiveDescriptor<?>> retVal = new LinkedList<ActiveDescriptor<?>>();
             
             while (!orderedCreationList.isEmpty()) {
@@ -474,6 +528,8 @@ public class AsyncRunLevelContext {
             }
             
             return retVal;
+        } finally {
+            lock.unlock();
         }
         
     }
@@ -487,7 +543,8 @@ public class AsyncRunLevelContext {
      */
     public RunLevelFuture proceedTo(int level) throws CurrentlyRunningException {
         CurrentTaskFutureWrapper localTask;
-        synchronized (this) {
+        lock.lock();
+        try {
             boolean fullyThreaded = policy.equals(RunLevelController.ThreadingPolicy.FULLY_THREADED);
             
             if (currentTask != null) {
@@ -504,6 +561,8 @@ public class AsyncRunLevelContext {
                     timer));
             
             localTask = currentTask;
+        } finally {
+            lock.unlock();
         }
         
         // Do outside the lock so that when not fully threaded we do not hold the
@@ -513,8 +572,13 @@ public class AsyncRunLevelContext {
         return localTask;
     }
     
-    /* package */ synchronized void jobDone() {
-        currentTask = null;
+    /* package */ void jobDone() {
+        lock.lock();
+        try {
+            currentTask = null;
+        } finally {
+            lock.unlock();
+        }
     }
     
     /**
@@ -522,42 +586,81 @@ public class AsyncRunLevelContext {
      * 
      * @return The current task, may be null if there is no current task
      */
-    public synchronized RunLevelFuture getCurrentFuture() {
-        return currentTask;
-    }
-    
-    /* package */ synchronized void setMaximumThreads(int maximum) {
-        if (maximum < 1) {
-            maxThreads = 1;
-        }
-        else {
-            maxThreads = maximum;
+    public RunLevelFuture getCurrentFuture() {
+        lock.lock();
+        try {
+            return currentTask;
+        } finally {
+            lock.unlock();
         }
     }
     
-    /* package */ synchronized int getMaximumThreads() {
-        return maxThreads;
+    /* package */ void setMaximumThreads(int maximum) {
+        lock.lock();
+        try {
+            if (maximum < 1) {
+                maxThreads = 1;
+            } else {
+                maxThreads = maximum;
+            }
+        } finally {
+            lock.unlock();
+        }
     }
     
-    /* package */ synchronized void clearErrors() {
-        levelErrorMap.clear();
-        wasCancelled = false;
+    /* package */ int getMaximumThreads() {
+        lock.lock();
+        try {
+            return maxThreads;
+        } finally {
+            lock.unlock();
+        }
     }
     
-    /* package */ synchronized void setCancelTimeout(long cancelTimeout) {
-        this.cancelTimeout = cancelTimeout;
+    /* package */ void clearErrors() {
+        lock.lock();
+        try {
+            levelErrorMap.clear();
+            wasCancelled = false;
+        } finally {
+            lock.unlock();
+        }
     }
     
-    /* package */ synchronized long getCancelTimeout() {
-        return cancelTimeout;
+    /* package */ void setCancelTimeout(long cancelTimeout) {
+        lock.lock();
+        try {
+            this.cancelTimeout = cancelTimeout;
+        } finally {
+            lock.unlock();
+        }
     }
     
-    /* package */ synchronized Integer getModeOverride() {
-        return modeOverride;
+    /* package */ long getCancelTimeout() {
+        lock.lock();
+        try {
+            return cancelTimeout;
+        } finally {
+            lock.unlock();
+        }
     }
     
-    /* package */ synchronized void setModeOverride(Integer modeOverride) {
-        this.modeOverride = modeOverride;
+    /* package */ Integer getModeOverride() {
+        lock.lock();
+        try {
+            return modeOverride;
+        } finally {
+            lock.unlock();
+        }
+    }
+    
+    /* package */ void setModeOverride(Integer modeOverride) {
+        lock.lock();
+        try {
+            this.modeOverride = modeOverride;
+        } finally {
+            lock.unlock();
+        }
     }
     
     private static class RunLevelControllerThread extends Thread {

--- a/hk2-runlevel/src/main/java/org/glassfish/hk2/runlevel/internal/CurrentTaskFuture.java
+++ b/hk2-runlevel/src/main/java/org/glassfish/hk2/runlevel/internal/CurrentTaskFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,6 +25,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.Descriptor;
@@ -51,6 +53,7 @@ import org.glassfish.hk2.runlevel.utilities.Utilities;
  *
  */
 public class CurrentTaskFuture implements ChangeableRunLevelFuture {
+    private final ReentrantLock lock = new ReentrantLock();
     private final AsyncRunLevelContext asyncContext;
     private final Executor executor;
     private final ServiceLocator locator;
@@ -114,9 +117,12 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
         UpAllTheWay localUpAllTheWay;
         DownAllTheWay localDownAllTheWay;
         
-        synchronized (this) {
+        lock.lock();
+        try {
             localUpAllTheWay = upAllTheWay;
             localDownAllTheWay = downAllTheWay;
+        } finally {
+            lock.unlock();
         }
         
         if (localUpAllTheWay != null || localDownAllTheWay != null) {
@@ -147,17 +153,23 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
     
     @Override
     public boolean isUp() {
-        synchronized (this) {
+        lock.lock();
+        try {
             if (upAllTheWay != null) return true;
             return false;
+        } finally {
+            lock.unlock();
         }
     }
     
     @Override
     public boolean isDown() {
-        synchronized (this) {
+        lock.lock();
+        try {
             if (downAllTheWay != null) return true;
             return false;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -167,8 +179,10 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
         // Not locking in this order can cause deadlocks
-        synchronized (asyncContext) {
-            synchronized (this) {
+        try {
+            asyncContext.lock.lock();
+            try {
+                lock.lock();
                 if (done) return false;
                 if (cancelled) return false;
             
@@ -182,7 +196,11 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                 }
             
                 return true;
+            } finally {
+                lock.unlock();
             }
+        } finally {
+            asyncContext.lock.unlock();
         }
     }
 
@@ -191,8 +209,11 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
      */
     @Override
     public boolean isCancelled() {
-        synchronized (this) {
+        lock.lock();
+        try {
             return cancelled;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -201,15 +222,21 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
      */
     @Override
     public boolean isDone() {
-        synchronized (this) {
+        lock.lock();
+        try {
             return done;
+        } finally {
+            lock.unlock();
         }
     }
     
     @Override
     public int getProposedLevel() {
-        synchronized (this) {
+        lock.lock();
+        try {
             return proposedLevel;
+        } finally {
+            lock.unlock();
         }
     }
     
@@ -217,7 +244,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
     public int changeProposedLevel(int proposedLevel) {
         int oldProposedVal;
         boolean needGo = false;
-        synchronized (this) {
+        lock.lock();
+        try {
             if (done) throw new IllegalStateException("Cannot change the proposed level of a future that is already complete");
             if (!inCallback) throw new IllegalStateException(
                     "changeProposedLevel must only be called from inside a RunLevelListener callback method");
@@ -262,6 +290,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                 // Should be impossible
                 throw new AssertionError("Can not determine previous job");
             }
+        } finally {
+            lock.unlock();
         }
         
         if (needGo) {
@@ -272,8 +302,11 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
     }
     
     private void setInCallback(boolean inCallback) {
-        synchronized (this) {
+        lock.lock();
+        try {
             this.inCallback = inCallback;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -297,13 +330,16 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
     public Object get(long timeout, TimeUnit unit) throws InterruptedException,
             ExecutionException, TimeoutException {
         AllTheWay allTheWay = null;
-        synchronized (this) {
+        lock.lock();
+        try {
             if (upAllTheWay != null) {
                 allTheWay = upAllTheWay;
             }
             else if (downAllTheWay != null) {
                 allTheWay = downAllTheWay;
             }
+        } finally {
+            lock.unlock();
         }
         
         if (allTheWay == null) return null;
@@ -313,13 +349,16 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
             try {
                 result = allTheWay.waitForResult(timeout, unit);
                 if (result == null) {
-                    synchronized (this) {
+                    lock.lock();
+                    try {
                         if (upAllTheWay != null) {
                             allTheWay = upAllTheWay;
                         }
                         else if (downAllTheWay != null) {
                             allTheWay = downAllTheWay;
                         }
+                    } finally {
+                        lock.unlock();
                     }
                     
                     continue;
@@ -329,15 +368,21 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                     throw new TimeoutException();
                 }
                 
-                synchronized (this) {
+                lock.lock();
+                try {
                     done = true;
+                } finally {
+                    lock.unlock();
                 }
                 
                 return null;
             }
             catch (MultiException me) {
-                synchronized (this) {
+                lock.lock();
+                try {
                     done = true;
+                } finally {
+                    lock.unlock();
                 }
                 
                 throw new ExecutionException(me);
@@ -441,7 +486,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
     }
     
     private class UpAllTheWay implements AllTheWay {
-        private final Object lock = new Object();
+        private final ReentrantLock lock = new ReentrantLock();
+        private final Condition condition = lock.newCondition();
         
         private int goingTo;
         private final int maxThreads;
@@ -476,10 +522,13 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
         }
         
         private void cancel() {
-            synchronized (lock) {
+            lock.lock();
+            try {
                 cancelled = true;
                 asyncContext.levelCancelled();
                 currentJob.cancel();
+            } finally {
+                lock.unlock();
             }
         }
         
@@ -487,11 +536,12 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
         public Boolean waitForResult(long timeout, TimeUnit unit) throws InterruptedException, MultiException {
             long totalWaitTimeMillis = TimeUnit.MILLISECONDS.convert(timeout, unit);
             
-            synchronized (lock) {
+            lock.lock();
+            try {
                 while (totalWaitTimeMillis > 0L && !done && !repurposed) {
                     long startTime = System.currentTimeMillis();
                     
-                    lock.wait(totalWaitTimeMillis);
+                    condition.await(totalWaitTimeMillis, TimeUnit.MILLISECONDS);
                     
                     long elapsedTime = System.currentTimeMillis() - startTime;
                     totalWaitTimeMillis -= elapsedTime;
@@ -504,21 +554,27 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                 }
                 
                 return done;
+            } finally {
+                lock.unlock();
             }
         }
         
         private void setGoingTo(int goingTo, boolean repurposed) {
-            synchronized (lock) {
+            lock.lock();
+            try {
                 this.goingTo = goingTo;
                 if (repurposed) {
                     this.repurposed = true;
                 }
+            } finally {
+                lock.unlock();
             }
         }
         
         private void go() {
             if (useThreads) {
-                synchronized (lock) {
+                lock.lock();
+                try {
                     workingOn++;
                     if (workingOn > goingTo) {
                         if (!repurposed) {
@@ -527,7 +583,7 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                             done = true;
                         }
                         
-                        lock.notifyAll();
+                        condition.signalAll();
                         return;
                     }
             
@@ -541,12 +597,15 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
             
                     executor.execute(currentJob);
                     return;
+                } finally {
+                    lock.unlock();
                 }
             }
                 
             workingOn++;
             while (workingOn <= goingTo) {
-                synchronized (lock) {
+                lock.lock();
+                try {
                     if (done) break;
                     
                     currentJob = new UpOneLevel(workingOn,
@@ -556,6 +615,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                             sorters,
                             0,
                             cancelTimeout);
+                } finally {
+                    lock.unlock();
                 }
                 
                 currentJob.run();
@@ -563,7 +624,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                 workingOn++;
             }
              
-            synchronized (lock) {
+            lock.lock();
+            try {
                 if (done) return;
                 
                 if (!repurposed) {
@@ -572,7 +634,9 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                     done = true;
                 }
                 
-                lock.notifyAll();
+                condition.signalAll();
+            } finally {
+                lock.unlock();
             }
         }
         
@@ -584,22 +648,28 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                 
                 downer.run();
                 
-                synchronized (lock) {                    
+                lock.lock();
+                try {                    
                     done = true;
                     this.exception = accumulatedExceptions;
-                    lock.notifyAll();
+                    condition.signalAll();
                     
                     asyncContext.jobDone();
+                } finally {
+                    lock.unlock();
                 }
                 
                 return;
             }
             
             DownAllTheWay downer = null;
-            synchronized (lock) {
+            lock.lock();
+            try {
                 if (cancelled) {
                     downer = new DownAllTheWay(workingOn - 1, null, null);
                 }
+            } finally {
+                lock.unlock();
             }
             
             if (downer != null) {
@@ -607,13 +677,16 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                 
                 invokeOnCancelled(future, workingOn - 1, listeners);
                 
-                synchronized (lock) {
+                lock.lock();
+                try {
                     done = true;
-                    lock.notifyAll();
+                    condition.signalAll();
                         
                     asyncContext.jobDone();
                         
                     return;
+                } finally {
+                    lock.unlock();
                 }
             }
             
@@ -627,8 +700,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
     }
     
     private class UpOneLevel implements Runnable {
-        private final Object lock = new Object();
-        private final Object queueLock = new Object();
+        private final ReentrantLock lock = new ReentrantLock();
+        private final ReentrantLock queueLock = new ReentrantLock();
         private final int upToThisLevel;
         private final CurrentTaskFuture currentTaskFuture;
         private final List<ServiceHandle<RunLevelListener>> listeners;
@@ -662,28 +735,40 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
         }
         
         private void cancel() {
-            synchronized (lock) {
+            lock.lock();
+            try {
                 cancelled = true;
                 hardCanceller = new CancelTimer(this);
                 timer.schedule(hardCanceller, cancelTimeout);
+            } finally {
+                lock.unlock();
             }
         }
         
         private void hardCancel() {
-            synchronized (asyncContext) {
-                synchronized (lock) {
+            asyncContext.lock.lock();
+            try {
+                lock.lock();
+                try {
                     hardCancelled = true;
+                } finally {
+                    lock.unlock();
                 }
                 
                 HashSet<ServiceHandle<?>> poisonMe;
-                synchronized (queueLock) {
+                queueLock.lock();
+                try {
                     poisonMe = new HashSet<ServiceHandle<?>>(outstandingHandles);
                     outstandingHandles.clear();
+                } finally {
+                    queueLock.unlock();
                 }
                 
                 for (ServiceHandle<?> handle : poisonMe) {
                     asyncContext.hardCancelOne(handle.getActiveDescriptor());
                 }
+            } finally {
+                asyncContext.lock.unlock();
             }
             
             master.currentJobComplete(null);
@@ -721,7 +806,7 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
 
         @Override
         public void run() {
-            Object jobsLock = new Object();
+            ReentrantLock jobsLock = new ReentrantLock();
             List<ServiceHandle<?>> jobs = locator.getAllServiceHandles(new IndexedFilter() {
 
                 @Override
@@ -763,7 +848,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
         }
         
         private void fail(Throwable th, Descriptor descriptor) {
-            synchronized (lock) {
+            lock.lock();
+            try {
                 if (hardCancelled) return;
                 
                 ErrorInformation info = invokeOnError(currentTaskFuture, th,
@@ -778,12 +864,15 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                 }
                 
                 accumulatedExceptions.addError(th);
+            } finally {
+                lock.unlock();
             }
         }
         
         private void jobComplete() {
             boolean complete = false;
-            synchronized (lock) {
+            lock.lock();
+            try {
                 if (hardCancelled) return;
                 
                 completedJobs++;
@@ -794,6 +883,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                         hardCanceller = null;
                     }
                 }
+            } finally {
+                lock.unlock();
             }
             
             if (complete) {
@@ -823,6 +914,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
      *
      */
     private class DownAllTheWay implements Runnable, AllTheWay {
+        private final ReentrantLock lock = new ReentrantLock();
+        private final Condition lockCondition = lock.newCondition();
         private int goingTo;
         private CurrentTaskFuture future;
         private final List<ServiceHandle<RunLevelListener>> listeners;
@@ -837,6 +930,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
         private ActiveDescriptor<?> lastErrorDescriptor = null;
         
         private List<ActiveDescriptor<?>> queue = Collections.emptyList();
+        private ReentrantLock queueLock = new ReentrantLock();
+        private Condition queueCondition = queueLock.newCondition();
         private boolean downHardCancelled = false;
         
         private HardCancelDownTimer hardCancelDownTimer = null;
@@ -860,36 +955,52 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
         
         private void cancel() {
             List<ActiveDescriptor<?>> localQueue;
-            
-            synchronized (this) {
+
+            ReentrantLock localQueueLock;
+            Condition localQueueCondition;
+            lock.lock();
+            try {
                 if (cancelled) return; // idempotent
                 cancelled = true;
                 
                 if (done) return;
                 
                 localQueue = queue;
+                localQueueLock = queueLock;
+                localQueueCondition = queueCondition;
+            } finally {
+                lock.unlock();
             }
                 
-            synchronized (localQueue) {
+            queueLock.lock();
+            try {
                 if (localQueue.isEmpty()) return;
-                
-                hardCancelDownTimer = new HardCancelDownTimer(this, localQueue);
+
+                hardCancelDownTimer = new HardCancelDownTimer(this, localQueue, localQueueLock, localQueueCondition);
                 timer.schedule(hardCancelDownTimer, cancelTimeout, cancelTimeout);
+            } finally {
+                queueLock.unlock();
             }
         }
         
         private void setGoingTo(int goingTo, boolean repurposed) {
-            synchronized (this) {
+            lock.lock();
+            try {
                 this.goingTo = goingTo;
                 if (repurposed) {
                     this.repurposed = true;
                 }
+            } finally {
+                lock.unlock();
             }
         }
         
         private int getGoingTo() {
-            synchronized (this) {
+            lock.lock();
+            try {
                 return goingTo;
+            } finally {
+                lock.unlock();
             }
         }
 
@@ -898,9 +1009,12 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
             while (workingOn > getGoingTo()) {
                 boolean runOnCancelled;
                 boolean localCancelled;
-                synchronized (this) {
+                lock.lock();
+                try {
                     localCancelled = cancelled;
                     runOnCancelled = cancelled && (future != null);
+                } finally {
+                    lock.unlock();
                 }
                 
                 if (runOnCancelled) {
@@ -908,7 +1022,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                     invokeOnCancelled(future, workingOn, listeners);
                 }
                 
-                synchronized (this) {
+                lock.lock();
+                try {
                     if (localCancelled) {
                         asyncContext.jobDone();
                         
@@ -918,6 +1033,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                         
                         return;
                     }
+                } finally {
+                    lock.unlock();
                 }
                 
                 int proceedingTo = workingOn - 1;
@@ -931,21 +1048,29 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                 
                 // But we don't call the proceedTo until all those services are gone
                 List<ActiveDescriptor<?>> localQueue = asyncContext.getOrderedListOfServicesAtLevel(workingOn);
-                synchronized(this) {
+                ReentrantLock localQueueLock = new ReentrantLock();
+                Condition localQueueCondition = localQueueLock.newCondition();
+                lock.lock();
+                try {
                     queue = localQueue;
+                    queueLock = localQueueLock;
+                    queueCondition = localQueueCondition;
+                }  finally {
+                    lock.unlock();
                 }
                 
                 ErrorInformation errorInfo = null;
-                synchronized (queue) {
+                queueLock.lock();
+                try {
                     for (;;) {
-                        DownQueueRunner currentRunner = new DownQueueRunner(queue, queue, this, locator);
+                        DownQueueRunner currentRunner = new DownQueueRunner(queueLock, queueCondition, queue, this, locator);
                         executor.execute(currentRunner);
                     
                         lastError = null;
                         for (;;) {
                             while (!queue.isEmpty() && (lastError == null) && (downHardCancelled == false)) {
                                 try {
-                                    queue.wait();
+                                    queueCondition.await();
                                 }
                                 catch (InterruptedException ie) {
                                     throw new RuntimeException(ie);
@@ -976,15 +1101,25 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                             break;
                         }
                     }
+                } finally {
+                    queueLock.unlock();
                 }
                 
-                synchronized(this) {
+                lock.lock();
+                try {
                     queue = Collections.emptyList();
+                    queueLock = new ReentrantLock();
+                    queueCondition = queueLock.newCondition();
+                } finally {
+                    lock.unlock();
                 }
                 
                 if (errorInfo != null && ErrorInformation.ErrorAction.GO_TO_NEXT_LOWER_LEVEL_AND_STOP.equals(errorInfo.getAction())) {
-                    synchronized (this) {
+                    lock.lock();
+                    try {
                         goingTo = workingOn;
+                    } finally {
+                        lock.unlock();
                     }
                 }
                 
@@ -1001,14 +1136,17 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                 return;
             }
             
-            synchronized (this) {
+            lock.lock();
+            try {
                 if (!repurposed) {
                     asyncContext.jobDone();
                 
                     done = true;
                 }
                 
-                this.notifyAll();
+                lockCondition.signalAll();
+            }  finally {
+                lock.unlock();
             }
             
         }
@@ -1017,11 +1155,12 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
         public Boolean waitForResult(long timeout, TimeUnit unit) throws InterruptedException, MultiException {
             long totalWaitTimeMillis = TimeUnit.MILLISECONDS.convert(timeout, unit);
             
-            synchronized (this) {
+            lock.lock();
+            try {
                 while (totalWaitTimeMillis > 0L && !done && !repurposed) {
                     long startTime = System.currentTimeMillis();
                     
-                    this.wait(totalWaitTimeMillis);
+                    lockCondition.await(totalWaitTimeMillis, TimeUnit.MILLISECONDS);
                     
                     long elapsedTime = System.currentTimeMillis() - startTime;
                     totalWaitTimeMillis -= elapsedTime;
@@ -1030,6 +1169,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                 if (repurposed) return null;
                 
                 return done;
+            } finally {
+                lock.unlock();
             }
         }
         
@@ -1038,28 +1179,35 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
     private static class HardCancelDownTimer extends TimerTask {
         private final DownAllTheWay parent;
         private final List<ActiveDescriptor<?>> queue;
+        private final ReentrantLock localQueueLock;
+        private final Condition localQueueCondition;
         
         private int lastQueueSize;
-        
-        private HardCancelDownTimer(DownAllTheWay parent, List<ActiveDescriptor<?>> queue) {
+
+        private HardCancelDownTimer(DownAllTheWay parent, List<ActiveDescriptor<?>> queue, ReentrantLock localQueueLock, Condition localQueueCondition) {
             this.parent = parent;
             this.queue = queue;
+            this.localQueueLock = localQueueLock;
+            this.localQueueCondition = localQueueCondition;
             lastQueueSize = queue.size();
         }
 
         @Override
         public void run() {
-            synchronized (queue) {
+            localQueueLock.lock();
+            try {
                 int currentSize = queue.size();
                 if (currentSize == 0) return;
                 
                 if (currentSize == lastQueueSize) {
                     parent.downHardCancelled = true;
-                    queue.notify();
+                    localQueueCondition.signal();
                 }
                 else {
                     lastQueueSize = currentSize;
                 }
+            } finally {
+                localQueueLock.unlock();
             }
         }
     }
@@ -1067,20 +1215,20 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
     private static class QueueRunner implements Runnable {
         private final ServiceLocator locator;
         private final AsyncRunLevelContext asyncContext;
-        private final Object queueLock;
+        private final ReentrantLock queueLock;
         private final List<ServiceHandle<?>> queue;
         private final UpOneLevel parent;
-        private final Object parentLock;
+        private final ReentrantLock parentLock;
         private final int maxThreads;
         private ServiceHandle<?> wouldHaveBlocked;
         private final HashSet<ActiveDescriptor<?>> alreadyTried = new HashSet<ActiveDescriptor<?>>();
         
         private QueueRunner(ServiceLocator locator,
                 AsyncRunLevelContext asyncContext,
-                Object queueLock,
+                            ReentrantLock queueLock,
                 List<ServiceHandle<?>> queue,
                 UpOneLevel parent,
-                Object parentLock,
+                            ReentrantLock parentLock,
                 int maxThreads) {
             this.locator = locator;
             this.asyncContext = asyncContext;
@@ -1097,7 +1245,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
             for (;;) {
                 ServiceHandle<?> job;
                 boolean block;
-                synchronized(queueLock) {
+                queueLock.lock();
+                try {
                     if (runningHandle != null) parent.jobFinished(runningHandle);
                     
                     if (wouldHaveBlocked != null) {
@@ -1139,6 +1288,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                     
                     parent.jobRunning(job);
                     runningHandle = job;
+                } finally {
+                    queueLock.unlock();
                 }
                 
                 oneJob(job, block);
@@ -1199,8 +1350,11 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
             boolean completed = true;
             try {
                 boolean ok;
-                synchronized (parentLock) {
+                parentLock.lock();
+                try {
                     ok = (!parent.cancelled && (parent.accumulatedExceptions == null));
+                } finally {
+                    parentLock.unlock();
                 }
                 
                 if (!block && isWouldBlockRightNow(new HashSet<ActiveDescriptor<?>>(), fService.getActiveDescriptor())) {
@@ -1236,17 +1390,20 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
     }
     
     private static class DownQueueRunner implements Runnable {
-        private final Object queueLock;
+        private final ReentrantLock queueLock;
+        private final Condition queueCondition;
         private final List<ActiveDescriptor<?>> queue;
         private final DownAllTheWay parent;
         private final ServiceLocator locator;
         private boolean caput;
         
-        private DownQueueRunner(Object queueLock,
+        private DownQueueRunner(ReentrantLock queueLock,
+                                Condition queueCondition,
                 List<ActiveDescriptor<?>> queue,
                 DownAllTheWay parent,
                 ServiceLocator locator) {
-            this.queueLock = queue;
+            this.queueLock = queueLock;
+            this.queueCondition = queueCondition;
             this.queue = queue;
             this.parent = parent;
             this.locator = locator;
@@ -1255,25 +1412,37 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
         @Override
         public void run() {
             for (;;) {
-                ActiveDescriptor<?> job = null;
-                synchronized (queueLock) {
+                ActiveDescriptor<?> job;
+                queueLock.lock();
+                try {
                     if (caput) return;
                     
                     if (queue.isEmpty()) {
-                        queueLock.notify();
+                        queueCondition.signal();
                         return;
                     }
-                    job = queue.remove(0);
+                    job = queue.get(0);
+                } finally {
+                    queueLock.unlock();
                 }
                 
                 try {
                     locator.getServiceHandle(job).destroy();
-                }
-                catch (Throwable th) {
-                    synchronized (queueLock) {
+                } catch (Throwable th) {
+                    queueLock.lock();
+                    try {
                         parent.lastError = th;
                         parent.lastErrorDescriptor = job;
                         queueLock.notify();
+                    } finally {
+                        queueLock.unlock();
+                    }
+                } finally {
+                    queueLock.lock();
+                    try {
+                        queue.remove(job);
+                    } finally {
+                        queueLock.unlock();
                     }
                 }
             }

--- a/hk2-runlevel/src/main/java/org/glassfish/hk2/runlevel/internal/CurrentTaskFuture.java
+++ b/hk2-runlevel/src/main/java/org/glassfish/hk2/runlevel/internal/CurrentTaskFuture.java
@@ -1028,8 +1028,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                         asyncContext.jobDone();
                         
                         done = true;
-                        
-                        this.notifyAll();
+
+                        lockCondition.signalAll();
                         
                         return;
                     }
@@ -1433,7 +1433,7 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                     try {
                         parent.lastError = th;
                         parent.lastErrorDescriptor = job;
-                        queueLock.notify();
+                        queueCondition.signal();
                     } finally {
                         queueLock.unlock();
                     }

--- a/hk2-utils/src/main/java/org/glassfish/hk2/utilities/cache/internal/LRUCacheCheapRead.java
+++ b/hk2-utils/src/main/java/org/glassfish/hk2/utilities/cache/internal/LRUCacheCheapRead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.utilities.cache.CacheEntry;
 import org.glassfish.hk2.utilities.cache.CacheKeyFilter;
@@ -41,7 +42,7 @@ import org.glassfish.hk2.utilities.cache.LRUCache;
  */
 public class LRUCacheCheapRead<K,V> extends LRUCache<K,V> {
 
-    final Object prunningLock = new Object();
+    final ReentrantLock prunningLock = new ReentrantLock();
 
     final int maxCacheSize;
     Map<K,CacheEntryImpl<K, V>> cache = new ConcurrentHashMap<K, CacheEntryImpl<K,V>>();
@@ -64,12 +65,15 @@ public class LRUCacheCheapRead<K,V> extends LRUCache<K,V> {
     @Override
     public CacheEntry put(K key, V value) {
         CacheEntryImpl<K, V> entry = new CacheEntryImpl<K, V>(key, value, this);
-        synchronized (prunningLock) {
+        prunningLock.lock();
+        try {
             if (cache.size() + 1 > maxCacheSize) {
                 removeLRUItem();
             }
             cache.put(key, entry);
             return entry;
+        } finally {
+            prunningLock.unlock();
         }
     }
 

--- a/hk2-utils/src/main/java/org/glassfish/hk2/utilities/cache/internal/WeakCARCacheImpl.java
+++ b/hk2-utils/src/main/java/org/glassfish/hk2/utilities/cache/internal/WeakCARCacheImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,7 @@ package org.glassfish.hk2.utilities.cache.internal;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.utilities.cache.CacheKeyFilter;
 import org.glassfish.hk2.utilities.cache.Computable;
@@ -46,7 +47,8 @@ public class WeakCARCacheImpl<K,V> implements WeakCARCache<K, V> {
     
     // The target size of t1, adaptive
     private int p = 0;
-    
+
+    private final ReentrantLock lock = new ReentrantLock();
     private final AtomicLong hits = new AtomicLong(0L);
     private final AtomicLong tries = new AtomicLong(0L);
     
@@ -92,7 +94,8 @@ public class WeakCARCacheImpl<K,V> implements WeakCARCache<K, V> {
             return value;
         }
         
-        synchronized (this) {
+        lock.lock();
+        try {
             value = getValueFromT(key);
             if (value != null) {
                 hits.getAndIncrement();
@@ -162,6 +165,8 @@ public class WeakCARCacheImpl<K,V> implements WeakCARCache<K, V> {
                 b2.remove(key);
                 t2.put(key, new CarValue<V>(value));
             }
+        } finally {
+            lock.unlock();
         }
         
         return value;
@@ -211,32 +216,47 @@ public class WeakCARCacheImpl<K,V> implements WeakCARCache<K, V> {
      * @see org.glassfish.hk2.utilities.cache.WeakCARCache#getKeySize()
      */
     @Override
-    public synchronized int getKeySize() {
-        return t1.size() + t2.size() + b1.size() + b2.size();
+    public int getKeySize() {
+        lock.lock();
+        try {
+            return t1.size() + t2.size() + b1.size() + b2.size();
+        }  finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.utilities.cache.WeakCARCache#getValueSize()
      */
     @Override
-    public synchronized int getValueSize() {
-        return t1.size() + t2.size();
+    public int getValueSize() {
+        lock.lock();
+        try {
+            return t1.size() + t2.size();
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.utilities.cache.WeakCARCache#clear()
      */
     @Override
-    public synchronized void clear() {
-        t1.clear();
-        t2.clear();
-        b1.clear();
-        b2.clear();
-        
-        p = 0;
-        
-        tries.set(0);
-        hits.set(0);
+    public void clear() {
+        lock.lock();
+        try {
+            t1.clear();
+            t2.clear();
+            b1.clear();
+            b2.clear();
+
+            p = 0;
+
+            tries.set(0);
+            hits.set(0);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)
@@ -259,44 +279,59 @@ public class WeakCARCacheImpl<K,V> implements WeakCARCache<K, V> {
      * @see org.glassfish.hk2.utilities.cache.WeakCARCache#remove(java.lang.Object)
      */
     @Override
-    public synchronized boolean remove(K key) {
-        if (t1.remove(key) == null) {
-            if (t2.remove(key) == null) {
-                if (!b1.remove(key)) {
-                    return b2.remove(key);
+    public boolean remove(K key) {
+        lock.lock();
+        try {
+            if (t1.remove(key) == null) {
+                if (t2.remove(key) == null) {
+                    if (!b1.remove(key)) {
+                        return b2.remove(key);
+                    }
+
+                    return true;
                 }
-                
+
                 return true;
             }
-            
+
             return true;
+        } finally {
+            lock.unlock();
         }
-        
-        return true;
     }
     
     /* (non-Javadoc)
      * @see org.glassfish.hk2.utilities.cache.WeakCARCache#releaseMatching(org.glassfish.hk2.utilities.cache.CacheKeyFilter)
      */
     @Override
-    public synchronized void releaseMatching(CacheKeyFilter<K> filter) {
-        if (filter == null) return;
-        
-        b2.releaseMatching(filter);
-        b1.releaseMatching(filter);
-        t1.releaseMatching(filter);
-        t2.releaseMatching(filter);
+    public void releaseMatching(CacheKeyFilter<K> filter) {
+        lock.lock();
+        try {
+            if (filter == null) return;
+
+            b2.releaseMatching(filter);
+            b1.releaseMatching(filter);
+            t1.releaseMatching(filter);
+            t2.releaseMatching(filter);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.utilities.cache.WeakCARCache#clearStaleReferences()
      */
     @Override
-    public synchronized void clearStaleReferences() {
-        t1.clearStaleReferences();
-        t2.clearStaleReferences();
-        b1.clearStaleReferences();
-        b2.clearStaleReferences();
+    public void clearStaleReferences() {
+        lock.lock();
+        try {
+            t1.clearStaleReferences();
+            t2.clearStaleReferences();
+            b1.clearStaleReferences();
+            b2.clearStaleReferences();
+        } finally {
+            lock.unlock();
+        }
     }
     
     private static class CarValue<V> {

--- a/hk2-utils/src/main/java/org/glassfish/hk2/utilities/general/ValidatorUtilities.java
+++ b/hk2-utils/src/main/java/org/glassfish/hk2/utilities/general/ValidatorUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,6 +19,7 @@ package org.glassfish.hk2.utilities.general;
 import java.lang.annotation.ElementType;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.validation.Path;
 import javax.validation.TraversableResolver;
@@ -36,6 +37,7 @@ import org.hibernate.validator.HibernateValidator;
  *
  */
 public class ValidatorUtilities {
+    private static final ReentrantLock slock = new ReentrantLock();
     private static final TraversableResolver TRAVERSABLE_RESOLVER = new TraversableResolver() {
         public boolean isReachable(Object traversableObject,
                 Path.Node traversableProperty, Class<?> rootBeanType,
@@ -76,23 +78,28 @@ public class ValidatorUtilities {
      * 
      * @return A javax bean validator for validating constraints
      */
-    public synchronized static Validator getValidator() {
-        if (validator == null) {
-            validator = AccessController.doPrivileged(new PrivilegedAction<Validator>() {
+    public static Validator getValidator() {
+        slock.lock();
+        try {
+            if (validator == null) {
+                validator = AccessController.doPrivileged(new PrivilegedAction<Validator>() {
 
-                @Override
-                public Validator run() {
-                    return initializeValidator();
-                }
-                
-            });
+                    @Override
+                    public Validator run() {
+                        return initializeValidator();
+                    }
+
+                });
+            }
+
+            if (validator == null) {
+                throw new IllegalStateException("Could not find a javax.validator");
+            }
+
+            return validator;
+        } finally {
+            slock.unlock();
         }
-        
-        if (validator == null) {
-            throw new IllegalStateException("Could not find a javax.validator");
-        }
-        
-        return validator;
     }
 
 }

--- a/hk2-utils/src/main/java/org/glassfish/hk2/utilities/general/internal/WeakHashClockImpl.java
+++ b/hk2-utils/src/main/java/org/glassfish/hk2/utilities/general/internal/WeakHashClockImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.utilities.cache.CacheKeyFilter;
 import org.glassfish.hk2.utilities.general.WeakHashClock;
@@ -36,7 +37,8 @@ public class WeakHashClockImpl<K,V> implements WeakHashClock<K,V> {
     private final boolean isWeak;
     private final ConcurrentHashMap<K, DoubleNode<K,V>> byKeyNotWeak;
     private final WeakHashMap<K, DoubleNode<K, V>> byKey;
-    
+
+    private final ReentrantLock lock = new ReentrantLock();
     private final ReferenceQueue<? super K> myQueue = new ReferenceQueue<K>();
     
     private DoubleNode<K, V> head;
@@ -117,7 +119,8 @@ public class WeakHashClockImpl<K,V> implements WeakHashClock<K,V> {
     public void put(final K key, final V value) {
         if (key == null || value == null) throw new IllegalArgumentException("key " + key + " or value " + value + " is null");
         
-        synchronized (this) {
+        lock.lock();
+        try {
             if (isWeak) {
                 removeStale();
             }
@@ -130,6 +133,8 @@ public class WeakHashClockImpl<K,V> implements WeakHashClock<K,V> {
             else {
                 byKeyNotWeak.put(key, addMe);
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -142,10 +147,13 @@ public class WeakHashClockImpl<K,V> implements WeakHashClock<K,V> {
         
         DoubleNode<K,V> node;
         if (isWeak) {
-            synchronized (this) {
+            lock.lock();
+            try {
                 removeStale();
         
                 node = byKey.get(key);
+            } finally {
+                lock.unlock();
             }
         }
         else {
@@ -164,7 +172,8 @@ public class WeakHashClockImpl<K,V> implements WeakHashClock<K,V> {
     public V remove(K key) {
         if (key == null) return null;
         
-        synchronized (this) {
+        lock.lock();
+        try {
             DoubleNode<K,V> node;
             if (isWeak) {
                 removeStale();
@@ -180,6 +189,8 @@ public class WeakHashClockImpl<K,V> implements WeakHashClock<K,V> {
             removeFromDLL(node);
             
             return node.getValue();
+        } finally {
+            lock.unlock();
         }
     }
     
@@ -187,26 +198,31 @@ public class WeakHashClockImpl<K,V> implements WeakHashClock<K,V> {
      * @see org.glassfish.hk2.utilities.general.WeakHashClock#releaseMatching(org.glassfish.hk2.utilities.cache.CacheKeyFilter)
      */
     @Override
-    public synchronized void releaseMatching(CacheKeyFilter<K> filter) {
-        if (filter == null) return;
-        
-        if (isWeak) {
-            removeStale();
-        }
-        
-        LinkedList<K> removeMe = new LinkedList<K>();
-        DoubleNode<K,V> current = head;
-        while (current != null) {
-            K key = current.getWeakKey().get();
-            if (key != null && filter.matches(key)) {
-                removeMe.add(key);
+    public void releaseMatching(CacheKeyFilter<K> filter) {
+        lock.lock();
+        try {
+            if (filter == null) return;
+
+            if (isWeak) {
+                removeStale();
             }
-            
-            current = current.getNext();
-        }
-        
-        for (K removeKey : removeMe) {
-            remove(removeKey);
+
+            LinkedList<K> removeMe = new LinkedList<K>();
+            DoubleNode<K, V> current = head;
+            while (current != null) {
+                K key = current.getWeakKey().get();
+                if (key != null && filter.matches(key)) {
+                    removeMe.add(key);
+                }
+
+                current = current.getNext();
+            }
+
+            for (K removeKey : removeMe) {
+                remove(removeKey);
+            }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -216,10 +232,13 @@ public class WeakHashClockImpl<K,V> implements WeakHashClock<K,V> {
     @Override
     public int size() {
         if (isWeak) {
-            synchronized (this) {
+            lock.lock();
+            try {
                 removeStale();
         
                 return byKey.size();
+            } finally {
+                lock.unlock();
             }
         }
         
@@ -257,36 +276,40 @@ public class WeakHashClockImpl<K,V> implements WeakHashClock<K,V> {
      * @see org.glassfish.hk2.utilities.general.WeakHashClock#next()
      */
     @Override
-    public synchronized Entry<K, V> next() {
-        DoubleNode<K,V> hardenedNode = moveDotNoWeak();
-        if (hardenedNode == null) return null;
+    public Entry<K, V> next() {
+        lock.lock();
         try {
-            final K key = hardenedNode.getHardenedKey();
-            final V value = hardenedNode.getValue();
-            
-            return new Map.Entry<K,V>() {
+            DoubleNode<K, V> hardenedNode = moveDotNoWeak();
+            if (hardenedNode == null) return null;
+            try {
+                final K key = hardenedNode.getHardenedKey();
+                final V value = hardenedNode.getValue();
 
-                @Override
-                public K getKey() {
-                    return key;
-                }
+                return new Map.Entry<K, V>() {
 
-                @Override
-                public V getValue() {
-                    return value;
-                }
+                    @Override
+                    public K getKey() {
+                        return key;
+                    }
 
-                @Override
-                public V setValue(V value) {
-                    throw new AssertionError("not implemented");
-                }
-                
-            };
-        }
-        finally {
-            hardenedNode.setHardenedKey(null);
-            
-            removeStale();
+                    @Override
+                    public V getValue() {
+                        return value;
+                    }
+
+                    @Override
+                    public V setValue(V value) {
+                        throw new AssertionError("not implemented");
+                    }
+
+                };
+            } finally {
+                hardenedNode.setHardenedKey(null);
+
+                removeStale();
+            }
+        } finally {
+            lock.unlock();
         }
     }
     
@@ -294,23 +317,32 @@ public class WeakHashClockImpl<K,V> implements WeakHashClock<K,V> {
      * @see org.glassfish.hk2.utilities.general.WeakHashClock#clear()
      */
     @Override
-    public synchronized void clear() {
-        if (isWeak) {
-            byKey.clear();
+    public void clear() {
+        lock.lock();
+        try {
+            if (isWeak) {
+                byKey.clear();
+            } else {
+                byKeyNotWeak.clear();
+            }
+
+            head = tail = dot = null;
+        } finally {
+            lock.unlock();
         }
-        else {
-            byKeyNotWeak.clear();
-        }
-        
-        head = tail = dot = null;
     }
     
     /* (non-Javadoc)
      * @see org.glassfish.hk2.utilities.general.WeakHashClock#clearStaleReferences()
      */
     @Override
-    public synchronized void clearStaleReferences() {
-        removeStale();
+    public void clearStaleReferences() {
+        lock.lock();
+        try {
+            removeStale();
+        }  finally {
+            lock.unlock();
+        }
     }
     
     private void removeStale() {
@@ -342,32 +374,36 @@ public class WeakHashClockImpl<K,V> implements WeakHashClock<K,V> {
     }
     
     @Override
-    public synchronized String toString() {
-        StringBuffer sb = new StringBuffer("WeakHashClockImpl({");
-        
-        boolean first = true;
-        DoubleNode<K,V> current = dot;
-        if (current != null) {
-            do {
-                K key = current.getWeakKey().get();
-                String keyString = (key == null) ? "null" : key.toString();
-            
-                if (first) {
-                    first = false;
-                
-                    sb.append(keyString);
-                }
-                else {
-                    sb.append("," + keyString);
-                }
-            
-                current = current.getNext();
-                if (current == null) current = head;
-            } while (current != dot);
+    public String toString() {
+        lock.lock();
+        try {
+            StringBuffer sb = new StringBuffer("WeakHashClockImpl({");
+
+            boolean first = true;
+            DoubleNode<K, V> current = dot;
+            if (current != null) {
+                do {
+                    K key = current.getWeakKey().get();
+                    String keyString = (key == null) ? "null" : key.toString();
+
+                    if (first) {
+                        first = false;
+
+                        sb.append(keyString);
+                    } else {
+                        sb.append("," + keyString);
+                    }
+
+                    current = current.getNext();
+                    if (current == null) current = head;
+                } while (current != dot);
+            }
+
+            sb.append("}," + System.identityHashCode(this) + ")");
+
+            return sb.toString();
+        } finally {
+            lock.unlock();
         }
-        
-        sb.append("}," + System.identityHashCode(this) + ")");
-              
-        return sb.toString();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -983,6 +983,16 @@
         </profile>
         <profile>
             <id>patched-project-release</id>
+            <distributionManagement>
+                <repository>
+                    <id>payara-nexus-enterprise-artifacts</id>
+                    <url>https://nexus.dev.payara.fish/repository/payara-enterprise-artifacts-private/</url>
+                </repository>
+                <snapshotRepository>
+                    <id>payara-nexus-enterprise-snapshots</id>
+                    <url>https://nexus.dev.payara.fish/repository/payara-enterprise-snapshots-private/</url>
+                </snapshotRepository>
+            </distributionManagement>
             <build>
                 <plugins>
                     <plugin>

--- a/spring-bridge/src/main/java/org/jvnet/hk2/spring/bridge/api/SpringScopeImpl.java
+++ b/spring-bridge/src/main/java/org/jvnet/hk2/spring/bridge/api/SpringScopeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,6 +16,8 @@
 
 package org.jvnet.hk2.spring.bridge.api;
 
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.ServiceHandle;
 import org.glassfish.hk2.api.ServiceLocator;
@@ -29,14 +31,20 @@ import org.springframework.beans.factory.config.Scope;
  *
  */
 public class SpringScopeImpl implements Scope {
+    private final ReentrantLock lock = new ReentrantLock();
     private ServiceLocator locator;
     
     /**
      * Sets the service locator to use with this scope
      * @param locator The (non-null) locator to use for this scope
      */
-    public synchronized void setServiceLocator(ServiceLocator locator) {
-        this.locator = locator;
+    public void setServiceLocator(ServiceLocator locator) {
+        lock.lock();
+        try {
+            this.locator = locator;
+        } finally {
+            lock.unlock();
+        }
     }
     
     /**
@@ -46,8 +54,13 @@ public class SpringScopeImpl implements Scope {
      * @param name The name to be used.  If null an anonymous service
      * locator will be used
      */
-    public synchronized void setServiceLocatorName(String name) {
-        locator = ServiceLocatorFactory.getInstance().create(name);
+    public void setServiceLocatorName(String name) {
+        lock.lock();
+        try {
+            locator = ServiceLocatorFactory.getInstance().create(name);
+        } finally {
+            lock.unlock();
+        }
     }
     
     /**
@@ -56,18 +69,28 @@ public class SpringScopeImpl implements Scope {
      * 
      * @return The {@link ServiceLocator} to be used with this scope
      */
-    public synchronized ServiceLocator getServiceLocator() {
-        return locator;
+    public ServiceLocator getServiceLocator() {
+        lock.lock();
+        try {
+            return locator;
+        } finally {
+            lock.unlock();
+        }
     }
     
-    private synchronized ServiceHandle<?> getServiceFromName(String id) {
-        if (locator == null) throw new IllegalStateException(
-                "ServiceLocator must be set");
-        
-        ActiveDescriptor<?> best = locator.getBestDescriptor(BuilderHelper.createTokenizedFilter(id));
-        if (best == null) return null;
-        
-        return locator.getServiceHandle(best);
+    private ServiceHandle<?> getServiceFromName(String id) {
+        lock.lock();
+        try {
+            if (locator == null) throw new IllegalStateException(
+                    "ServiceLocator must be set");
+
+            ActiveDescriptor<?> best = locator.getBestDescriptor(BuilderHelper.createTokenizedFilter(id));
+            if (best == null) return null;
+
+            return locator.getServiceHandle(best);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
FISH-11911: Adding fix to invalid reference of ClassAnalyzer from HK2-Locator

## Description

This is a bug fix to resolve the invalid reference for the ClassAnalyzer that is causing  exception of logs with the following content:

```
jakarta.ejb.EJBException: A MultiException has 1 exceptions.  They are:
1. java.lang.IllegalStateException: Could not find an implementation of ClassAnalyzer with name CdiInjecteeSkippingClassAnalyzer

	at com.sun.ejb.containers.EJBContainerTransactionManager.processSystemException(EJBContainerTransactionManager.java:723)
	at com.sun.ejb.containers.EJBContainerTransactionManager.completeNewTx(EJBContainerTransactionManager.java:652)
	at com.sun.ejb.containers.EJBContainerTransactionManager.postInvokeTx(EJBContainerTransactionManager.java:482)
	at com.sun.ejb.containers.BaseContainer.postInvokeTx(BaseContainer.java:4601)
	at com.sun.ejb.containers.BaseContainer.postInvoke(BaseContainer.java:2134)
	at com.sun.ejb.containers.BaseContainer.postInvoke(BaseContainer.java:2104)
	at com.sun.ejb.containers.EJBLocalObjectInvocationHandler.invoke(EJBLocalObjectInvocationHandler.java:220)
	at com.sun.ejb.containers.EJBLocalObjectInvocationHandlerDelegate.invoke(EJBLocalObjectInvocationHandlerDelegate.java:90)
	at jdk.proxy64/jdk.proxy64.$Proxy241.test(Unknown Source)
	at com.test.__EJB31_Generated__TestBA__Intf____Bean__.test(Unknown Source)
	at jdk.internal.reflect.GeneratedMethodAccessor80.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.jboss.weld.util.reflection.Reflections.invokeAndUnwrap(Reflections.java:412)
	at org.jboss.weld.module.ejb.EnterpriseBeanProxyMethodHandler.invoke(EnterpriseBeanProxyMethodHandler.java:133)
	at org.jboss.weld.bean.proxy.EnterpriseTargetBeanInstance.invoke(EnterpriseTargetBeanInstance.java:54)
	at 
```
### Testing Performed

You need to deploy the following application on Payara 5 to reproduce the case:

[sa3_server-feature-SAIII-44472-ClassCastAnalyzer-Reproducer.zip](https://github.com/user-attachments/files/23374555/sa3_server-feature-SAIII-44472-ClassCastAnalyzer-Reproducer.zip)

use the following command to create the ear file: mvn clean package

deploy on Payara 5:

<img width="1899" height="571" alt="image" src="https://github.com/user-attachments/assets/cd55869a-1e4e-442c-b750-aff0eded13ab" />

to install the ngnix server that is used by the rest client configuration do the following steps:

- stop payara 5 if you already deployed the reporoducer application
- as a requirement you need docker on your environment
- from the reproducer application and under the folder docker, execute the following command: docker compose up -d
-stop the container testserver-1, also you can remove that container after deleting
- we only need nginix to be consumed by our application on our local installation of Payara 5
<img width="1622" height="409" alt="image" src="https://github.com/user-attachments/assets/b2fa3492-5620-41b7-b768-51ac2fef56dc" />

- start again your local Payara 5 server with the application deployed.
- install JMeter and open the configuration located at the folder jmeter
- open the configuration of JMeter and change the Path on the HttpRequest configuration to use the following path:/test/test

<img width="1882" height="450" alt="image" src="https://github.com/user-attachments/assets/607d1af9-8ddd-424a-940b-a3c871c7876c" />

- execute the tests -see results on logs, in this case without the property set you will see the same error reported from the ticket:

```
[2025-11-05T14:37:57.948-0600] [Payara 5.81.0] [ADVERTENCIA] [] [org.glassfish.jersey.internal.Errors] [tid: _ThreadID=127 _ThreadName=http-thread-pool::http-listener-1(4)] [timeMillis: 1762375077948] [levelValue: 900] [[
  The following warnings have been detected: WARNING: HK2 failure has been detected in a code that does not run in an active Jersey Error scope.
WARNING: Unknown HK2 failure detected:
MultiException stack 1 of 1
java.lang.IllegalStateException: Could not find an implementation of ClassAnalyzer with name CdiInjecteeSkippingClassAnalyzer
	at org.jvnet.hk2.internal.ServiceLocatorImpl.getAnalyzer(ServiceLocatorImpl.java:2492)
	at org.jvnet.hk2.internal.Utilities.getClassAnalyzer(Utilities.java:144)
	at org.jvnet.hk2.internal.Utilities.justInject(Utilities.java:970)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.inject(ServiceLocatorImpl.java:1013)
	at org.glassfish.jersey.inject.hk2.AbstractHk2InjectionManager.inject(AbstractHk2InjectionManager.java:219)
	at org.glassfish.jersey.inject.hk2.ImmediateHk2InjectionManager.inject(ImmediateHk2InjectionManager.java:30)
	at org.glassfish.jersey.ext.cdi1x.internal.CdiComponentProvider$InjectionManagerInjectedCdiTarget.inject(CdiComponentProvider.java:685)
	at org.jboss.weld.bean.ManagedBean.create(ManagedBean.java:161)
``
- add the new property on the domain.xml ` -Djersey.config.analyzerReattemptInjection=true `
-stop server
-remove logs
-start again the server
-send again the tests from JMeter
-after finishing check logs
-you can't find any reference related to the CdiInjecteeSkippingClassAnalyzer issue